### PR TITLE
Fix Invalid Date display in comp report sales

### DIFF
--- a/src/components/ProcessedGallery/CompReportModal.tsx
+++ b/src/components/ProcessedGallery/CompReportModal.tsx
@@ -13,9 +13,10 @@ function formatPrice(value: number | null): string {
 }
 
 function formatDate(dateStr: string): string {
+  if (!dateStr) return '--';
   const d = new Date(dateStr);
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-    + ' ' + d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  if (isNaN(d.getTime())) return dateStr;
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
 const SourceSection: React.FC<{ result: CompResult }> = ({ result }) => {


### PR DESCRIPTION
## Summary

- Fix "Invalid Date Invalid Date" showing for eBay comp sale dates in the CompReportModal
- eBay sold listings return date strings like "Feb 14" (no year) which `new Date()` cannot parse
- The formatter was also appending a time portion that has no meaning for sale dates

## Changes

- **CompReportModal.tsx**: Harden `formatDate()` to guard against empty strings (returns `--`), fall back to the raw date string when `new Date()` produces an invalid result, and drop the `toLocaleTimeString` call since sale dates have no meaningful time component

## Test Plan

- [x] Open a card's comp report that has eBay sales — dates should display correctly (e.g. "Feb 14, 2026" or raw "Feb 14" if no year)
- [x] Verify dates from other sources (MarketMovers, CardLadder, SportsCardsPro) still render properly
- [x] Verify the "Generated" timestamp in the footer still formats correctly
- [x] Confirm no "Invalid Date" text appears anywhere in the modal

Closes #130