### PR TITLE
Add Personal and eBay default collections

### DIFF
--- a/server/src/routes/collections.ts
+++ b/server/src/routes/collections.ts
@@ -30,9 +30,10 @@ export function createCollectionRoutes(db: Database, auditService: AuditService)
       if (collection) {
         res.json(collection);
       } else {
-        // Auto-initialize and return
-        const newDefault = await db.initializeUserCollections(userId);
-        res.json(newDefault);
+        // Auto-initialize and return the default
+        const cols = await db.initializeUserCollections(userId);
+        const defaultCol = cols.find(c => c.isDefault) ?? cols[0];
+        res.json(defaultCol);
       }
     } catch (error) {
       console.error('Error getting default collection:', error);
@@ -199,8 +200,8 @@ export function createCollectionRoutes(db: Database, auditService: AuditService)
         return;
       }
 
-      const collection = await db.initializeUserCollections(userId);
-      res.json(collection);
+      const collections = await db.initializeUserCollections(userId);
+      res.json(collections);
     } catch (error) {
       console.error('Error initializing collections:', error);
       res.status(500).json({ error: 'Failed to initialize collections' });

--- a/src/components/Collections/Collections.tsx
+++ b/src/components/Collections/Collections.tsx
@@ -25,6 +25,8 @@ const Collections: React.FC = () => {
   const loadCollections = async () => {
     try {
       setLoading(true);
+      // Ensure default collections exist (idempotent — migrates legacy users too)
+      await apiService.initializeCollections().catch(() => {});
       const userCollections = await apiService.getCollections();
       setCollections(userCollections);
 


### PR DESCRIPTION
## Summary

- New users now get two default collections: **Personal** (default, indigo) and **eBay** (green) instead of a single "My Collection"
- Existing users with the legacy "My Collection" are automatically migrated: renamed to "Personal" and an "eBay" collection is added
- Collections page now triggers initialization on load so existing users are migrated on their next visit

Closes #136

## Changes

- **server/src/database.ts**: `initializeUserCollections` returns `Collection[]`, creates both collections for new users, migrates legacy "My Collection" → "Personal" and adds missing eBay collection for existing users
- **server/src/routes/collections.ts**: `GET /default` fallback extracts the default from the array; `POST /initialize` returns the full array
- **server/src/__tests__/database.test.ts**: Updated test for two-collection initialization plus new test covering legacy migration and idempotency
- **src/components/Collections/Collections.tsx**: Calls `initializeCollections()` on page load before fetching collections

## Test Plan

- [x] Register a new user — verify both Personal (default) and eBay collections appear
- [x] Log in as an existing user with "My Collection" — visit Collections page, verify it is renamed to "Personal" and eBay collection is added
- [x] Revisit Collections page — verify no duplicate collections are created (idempotent)
- [x] `cd server && npx tsc --noEmit` — no type errors
- [x] `cd server && npm test` — all tests pass (63 database tests including new migration test)