### PR TITLE
Fix 6 eBay CSV export gaps to match hand-crafted reference

### DIFF
--- a/server/src/__tests__/services/ebayExportService.test.ts
+++ b/server/src/__tests__/services/ebayExportService.test.ts
@@ -89,6 +89,7 @@ describe('EbayExportService', () => {
       const csvContent = fs.readFileSync(service.getOutputPath(), 'utf-8');
       const headerLine = csvContent.split('\n')[0];
       expect(headerLine).toContain('*Action(SiteID=US|Country=US|Currency=USD|Version=1193)');
+      expect(headerLine).toContain('Custom label (SKU)');
       expect(headerLine).toContain('*Category');
       expect(headerLine).toContain('*Title');
     });
@@ -105,9 +106,9 @@ describe('EbayExportService', () => {
       expect(result.totalCards).toBe(2);
 
       const csvContent = fs.readFileSync(service.getOutputPath(), 'utf-8');
-      // Count rows by looking for 'Add,' at start of CSV records (data rows start with Add)
-      const addRows = csvContent.split('\n').filter(l => l.startsWith('Add,'));
-      expect(addRows.length).toBe(2);
+      // Count rows by looking for 'Draft,' at start of CSV records (data rows start with Draft)
+      const draftRows = csvContent.split('\n').filter(l => l.startsWith('Draft,'));
+      expect(draftRows.length).toBe(2);
       // Header row
       expect(csvContent).toContain('*Action(SiteID=US|Country=US|Currency=USD|Version=1193)');
     });


### PR DESCRIPTION
## Summary

- Fix 6 quality gaps found by comparing the system-generated CSV against the hand-crafted `ebay-draft.csv` reference file
- All fixes are in `ebayExportService.ts` — condition mapping, SKU, action value, title/description format, and category IDs
- Generated CSV now closely matches the style and structure of hand-crafted listings

## Changes

- **Condition ID mapping**: `getConditionId()` now reads `card.grade` instead of `card.condition` — all graded cards get `2750`, ungraded get `3000`
- **SKU column**: Added `Custom label (SKU)` header and `generateSku()` method producing format like `MAYE-2024-329-PSA10` (graded) or `TROUT-2023-1-RAW` (ungraded)
- **Action value**: Changed from `Add` to `Draft` so listings require manual review before going live
- **Title quality**: Rewritten to include `setName`, use `card.grade` for display (e.g., `PSA 10`), use `isRookie` boolean for `RC`, and append `card.team` instead of `card.category`
- **Description quality**: Replaced HTML table format with clean `<p>/<b>` format — header, grade with serial number, pipe-separated features, team, notes, and grading-aware shipping line
- **Category ID**: All sports cards now use `215` (only Pokemon retains `183454`)
- **Tests**: Updated header assertion for new SKU column and row-counting to match `Draft` action prefix

## Test Plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npx jest ebayExportService` — all 12 tests pass
- [x] Generate CSV for test cards and compare against `ebay-draft.csv` format
- [x] Verify graded cards get condition ID `2750` and ungraded get `3000`
- [x] Verify SKU format for graded vs ungraded cards
- [x] Verify title includes setName, grade, RC flag, and team
- [x] Verify description uses `<p>/<b>` format with correct shipping line per card type

Closes #145