### PR TITLE
Add auto price alerts with configurable thresholds

### DIFF
--- a/server/drizzle/0011_price_alerts.sql
+++ b/server/drizzle/0011_price_alerts.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS price_alerts (
+  id text PRIMARY KEY NOT NULL,
+  cardId text NOT NULL,
+  userId text NOT NULL,
+  type text NOT NULL,
+  thresholdLow real,
+  thresholdHigh real,
+  isEnabled integer DEFAULT 1,
+  lastCheckedAt text,
+  lastTriggeredAt text,
+  triggerCount integer DEFAULT 0,
+  createdAt text NOT NULL,
+  updatedAt text NOT NULL,
+  FOREIGN KEY (cardId) REFERENCES cards(id) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (userId) REFERENCES users(id) ON UPDATE no action ON DELETE no action
+);
+CREATE INDEX IF NOT EXISTS idx_price_alerts_cardId ON price_alerts (cardId);
+CREATE INDEX IF NOT EXISTS idx_price_alerts_userId ON price_alerts (userId);
+CREATE INDEX IF NOT EXISTS idx_price_alerts_isEnabled ON price_alerts (isEnabled);
+
+CREATE TABLE IF NOT EXISTS price_alert_history (
+  id text PRIMARY KEY NOT NULL,
+  alertId text NOT NULL,
+  cardId text NOT NULL,
+  previousValue real NOT NULL,
+  currentValue real NOT NULL,
+  threshold real NOT NULL,
+  type text NOT NULL,
+  createdAt text NOT NULL,
+  FOREIGN KEY (alertId) REFERENCES price_alerts(id) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (cardId) REFERENCES cards(id) ON UPDATE no action ON DELETE no action
+);
+CREATE INDEX IF NOT EXISTS idx_alert_history_alertId ON price_alert_history (alertId);
+CREATE INDEX IF NOT EXISTS idx_alert_history_cardId ON price_alert_history (cardId);
+CREATE INDEX IF NOT EXISTS idx_alert_history_createdAt ON price_alert_history (createdAt);

--- a/server/drizzle/0011_price_alerts.sql
+++ b/server/drizzle/0011_price_alerts.sql
@@ -14,10 +14,13 @@ CREATE TABLE IF NOT EXISTS price_alerts (
   FOREIGN KEY (cardId) REFERENCES cards(id) ON UPDATE no action ON DELETE cascade,
   FOREIGN KEY (userId) REFERENCES users(id) ON UPDATE no action ON DELETE no action
 );
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS idx_price_alerts_cardId ON price_alerts (cardId);
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS idx_price_alerts_userId ON price_alerts (userId);
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS idx_price_alerts_isEnabled ON price_alerts (isEnabled);
-
+--> statement-breakpoint
 CREATE TABLE IF NOT EXISTS price_alert_history (
   id text PRIMARY KEY NOT NULL,
   alertId text NOT NULL,
@@ -30,6 +33,9 @@ CREATE TABLE IF NOT EXISTS price_alert_history (
   FOREIGN KEY (alertId) REFERENCES price_alerts(id) ON UPDATE no action ON DELETE cascade,
   FOREIGN KEY (cardId) REFERENCES cards(id) ON UPDATE no action ON DELETE no action
 );
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS idx_alert_history_alertId ON price_alert_history (alertId);
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS idx_alert_history_cardId ON price_alert_history (cardId);
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS idx_alert_history_createdAt ON price_alert_history (createdAt);

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1772668800000,
       "tag": "0010_storage_locations",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1772755200000,
+      "tag": "0011_price_alerts",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/helpers/testSetup.ts
+++ b/server/src/__tests__/helpers/testSetup.ts
@@ -26,6 +26,8 @@ import { createAuditLogRoutes } from '../../routes/auditLogs';
 import { createAdminUserRoutes } from '../../routes/adminUsers';
 import { createGradingSubmissionRoutes } from '../../routes/gradingSubmissions';
 import { createStorageRoutes } from '../../routes/storage';
+import { createPriceAlertRoutes } from '../../routes/priceAlerts';
+import PriceAlertService from '../../services/priceAlertService';
 import { Config } from '../../config';
 import path from 'path';
 import fs from 'fs';
@@ -115,6 +117,8 @@ export async function createTestApp(): Promise<TestContext> {
   app.use('/api/admin/users', createAdminUserRoutes(db, auditService));
   app.use('/api/grading-submissions', createGradingSubmissionRoutes(db, auditService));
   app.use('/api/storage', createStorageRoutes(db, auditService));
+  const priceAlertService = new PriceAlertService(db, eventService);
+  app.use('/api/price-alerts', createPriceAlertRoutes(db, auditService, priceAlertService));
 
   app.use(errorHandler);
 

--- a/server/src/__tests__/routes/priceAlerts.test.ts
+++ b/server/src/__tests__/routes/priceAlerts.test.ts
@@ -1,0 +1,255 @@
+import request from 'supertest';
+import { createTestApp, cleanupTestContext, TestContext } from '../helpers/testSetup';
+import { createCardData } from '../helpers/factories';
+
+describe('Price Alert Routes', () => {
+  let ctx: TestContext;
+  let token: string;
+
+  beforeAll(async () => {
+    ctx = await createTestApp();
+    const res = await request(ctx.app)
+      .post('/api/auth/register')
+      .send({ username: 'alertuser', email: 'alert@test.com', password: 'password123' });
+    token = res.body.token;
+  });
+
+  afterAll(async () => {
+    await cleanupTestContext(ctx);
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${token}` });
+
+  async function createCard(overrides = {}) {
+    const res = await request(ctx.app)
+      .post('/api/cards')
+      .set(auth())
+      .send(createCardData(overrides));
+    return res.body;
+  }
+
+  describe('POST /api/price-alerts', () => {
+    it('creates an above alert', async () => {
+      const card = await createCard({ currentValue: 50 });
+
+      const res = await request(ctx.app)
+        .post('/api/price-alerts')
+        .set(auth())
+        .send({ cardId: card.id, type: 'above', thresholdHigh: 100 });
+
+      expect(res.status).toBe(201);
+      expect(res.body.cardId).toBe(card.id);
+      expect(res.body.type).toBe('above');
+      expect(res.body.thresholdHigh).toBe(100);
+      expect(res.body.isEnabled).toBe(true);
+    });
+
+    it('creates a below alert', async () => {
+      const card = await createCard({ currentValue: 50 });
+
+      const res = await request(ctx.app)
+        .post('/api/price-alerts')
+        .set(auth())
+        .send({ cardId: card.id, type: 'below', thresholdLow: 20 });
+
+      expect(res.status).toBe(201);
+      expect(res.body.type).toBe('below');
+      expect(res.body.thresholdLow).toBe(20);
+    });
+
+    it('rejects missing cardId', async () => {
+      const res = await request(ctx.app)
+        .post('/api/price-alerts')
+        .set(auth())
+        .send({ type: 'above', thresholdHigh: 100 });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid type', async () => {
+      const card = await createCard();
+      const res = await request(ctx.app)
+        .post('/api/price-alerts')
+        .set(auth())
+        .send({ cardId: card.id, type: 'invalid', thresholdHigh: 100 });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects above alert without thresholdHigh', async () => {
+      const card = await createCard();
+      const res = await request(ctx.app)
+        .post('/api/price-alerts')
+        .set(auth())
+        .send({ cardId: card.id, type: 'above' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects below alert without thresholdLow', async () => {
+      const card = await createCard();
+      const res = await request(ctx.app)
+        .post('/api/price-alerts')
+        .set(auth())
+        .send({ cardId: card.id, type: 'below' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 401 without auth', async () => {
+      const res = await request(ctx.app)
+        .post('/api/price-alerts')
+        .send({ cardId: 'some-id', type: 'above', thresholdHigh: 100 });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET /api/price-alerts', () => {
+    it('returns alerts for the authenticated user', async () => {
+      const res = await request(ctx.app)
+        .get('/api/price-alerts')
+        .set(auth());
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThan(0);
+    });
+
+    it('returns 401 without auth', async () => {
+      const res = await request(ctx.app).get('/api/price-alerts');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET /api/price-alerts/card/:cardId', () => {
+    it('returns alerts for a specific card', async () => {
+      const card = await createCard({ currentValue: 75 });
+      await request(ctx.app)
+        .post('/api/price-alerts')
+        .set(auth())
+        .send({ cardId: card.id, type: 'above', thresholdHigh: 150 });
+
+      const res = await request(ctx.app)
+        .get(`/api/price-alerts/card/${card.id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.length).toBeGreaterThanOrEqual(1);
+      expect(res.body[0].cardId).toBe(card.id);
+    });
+  });
+
+  describe('PUT /api/price-alerts/:id', () => {
+    it('updates an alert threshold', async () => {
+      const card = await createCard({ currentValue: 50 });
+      const createRes = await request(ctx.app)
+        .post('/api/price-alerts')
+        .set(auth())
+        .send({ cardId: card.id, type: 'above', thresholdHigh: 100 });
+
+      const res = await request(ctx.app)
+        .put(`/api/price-alerts/${createRes.body.id}`)
+        .set(auth())
+        .send({ thresholdHigh: 200 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.thresholdHigh).toBe(200);
+    });
+
+    it('disables an alert', async () => {
+      const card = await createCard({ currentValue: 50 });
+      const createRes = await request(ctx.app)
+        .post('/api/price-alerts')
+        .set(auth())
+        .send({ cardId: card.id, type: 'below', thresholdLow: 10 });
+
+      const res = await request(ctx.app)
+        .put(`/api/price-alerts/${createRes.body.id}`)
+        .set(auth())
+        .send({ isEnabled: false });
+
+      expect(res.status).toBe(200);
+      expect(res.body.isEnabled).toBe(false);
+    });
+
+    it('returns 404 for non-existent alert', async () => {
+      const res = await request(ctx.app)
+        .put('/api/price-alerts/nonexistent')
+        .set(auth())
+        .send({ thresholdHigh: 200 });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 401 without auth', async () => {
+      const res = await request(ctx.app)
+        .put('/api/price-alerts/some-id')
+        .send({ thresholdHigh: 200 });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('DELETE /api/price-alerts/:id', () => {
+    it('deletes an alert', async () => {
+      const card = await createCard({ currentValue: 50 });
+      const createRes = await request(ctx.app)
+        .post('/api/price-alerts')
+        .set(auth())
+        .send({ cardId: card.id, type: 'above', thresholdHigh: 100 });
+
+      const res = await request(ctx.app)
+        .delete(`/api/price-alerts/${createRes.body.id}`)
+        .set(auth());
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      // Verify it's gone
+      const checkRes = await request(ctx.app)
+        .get(`/api/price-alerts/card/${card.id}`);
+      expect(checkRes.body.find((a: any) => a.id === createRes.body.id)).toBeUndefined();
+    });
+
+    it('returns 404 for non-existent alert', async () => {
+      const res = await request(ctx.app)
+        .delete('/api/price-alerts/nonexistent')
+        .set(auth());
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 401 without auth', async () => {
+      const res = await request(ctx.app)
+        .delete('/api/price-alerts/some-id');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/price-alerts/check', () => {
+    it('triggers an alert check', async () => {
+      const res = await request(ctx.app)
+        .post('/api/price-alerts/check')
+        .set(auth());
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('triggered');
+      expect(res.body).toHaveProperty('checked');
+    });
+
+    it('returns 401 without auth', async () => {
+      const res = await request(ctx.app)
+        .post('/api/price-alerts/check');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET /api/price-alerts/history', () => {
+    it('returns alert history for the user', async () => {
+      const res = await request(ctx.app)
+        .get('/api/price-alerts/history')
+        .set(auth());
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    it('returns 401 without auth', async () => {
+      const res = await request(ctx.app)
+        .get('/api/price-alerts/history');
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/server/src/__tests__/services/priceAlertService.test.ts
+++ b/server/src/__tests__/services/priceAlertService.test.ts
@@ -1,0 +1,152 @@
+import Database from '../../database';
+import EventService from '../../services/eventService';
+import PriceAlertService from '../../services/priceAlertService';
+
+describe('PriceAlertService', () => {
+  let db: Database;
+  let eventService: EventService;
+  let service: PriceAlertService;
+  let userId: string;
+
+  beforeAll(async () => {
+    db = new Database(':memory:');
+    await db.waitReady();
+    eventService = new EventService();
+    service = new PriceAlertService(db, eventService);
+
+    const user = await db.createUser({ username: 'alerttest', email: 'alerttest@test.com', password: 'password123' });
+    userId = user.id;
+  });
+
+  afterAll(async () => {
+    service.stop();
+    await db.close();
+  });
+
+  async function createTestCard(currentValue: number) {
+    return db.createCard({
+      userId,
+      player: 'Test Player',
+      team: 'Test Team',
+      year: 2023,
+      brand: 'Topps',
+      category: 'Baseball',
+      cardNumber: `${Math.random()}`,
+      condition: 'RAW',
+      purchasePrice: 10,
+      purchaseDate: '2023-01-01',
+      currentValue,
+      images: [],
+      notes: '',
+    });
+  }
+
+  describe('checkAlerts', () => {
+    it('triggers above alert when value exceeds threshold', async () => {
+      const card = await createTestCard(150);
+      await db.createPriceAlert(userId, {
+        cardId: card.id,
+        type: 'above',
+        thresholdHigh: 100,
+      });
+
+      const broadcastSpy = jest.spyOn(eventService, 'broadcast');
+      const result = await service.checkAlerts();
+
+      expect(result.triggered).toBeGreaterThanOrEqual(1);
+      expect(broadcastSpy).toHaveBeenCalledWith('price-alert', expect.objectContaining({
+        cardId: card.id,
+        type: 'above',
+      }));
+      broadcastSpy.mockRestore();
+    });
+
+    it('triggers below alert when value drops below threshold', async () => {
+      const card = await createTestCard(5);
+      await db.createPriceAlert(userId, {
+        cardId: card.id,
+        type: 'below',
+        thresholdLow: 10,
+      });
+
+      const broadcastSpy = jest.spyOn(eventService, 'broadcast');
+      const result = await service.checkAlerts();
+
+      expect(result.triggered).toBeGreaterThanOrEqual(1);
+      expect(broadcastSpy).toHaveBeenCalledWith('price-alert', expect.objectContaining({
+        cardId: card.id,
+        type: 'below',
+      }));
+      broadcastSpy.mockRestore();
+    });
+
+    it('does not trigger when value is within range', async () => {
+      const card = await createTestCard(50);
+      await db.createPriceAlert(userId, {
+        cardId: card.id,
+        type: 'above',
+        thresholdHigh: 100,
+      });
+
+      // Check how many alerts total are triggered (includes alerts from earlier tests)
+      const result = await service.checkAlerts();
+      // The alert for this specific card should NOT trigger since 50 < 100
+      const history = await db.getPriceAlertsByCard(card.id);
+      const alert = history[0];
+      expect(alert.lastTriggeredAt).toBeNull();
+    });
+
+    it('does not trigger disabled alerts', async () => {
+      const card = await createTestCard(200);
+      const alert = await db.createPriceAlert(userId, {
+        cardId: card.id,
+        type: 'above',
+        thresholdHigh: 50,
+      });
+      await db.updatePriceAlert(alert.id, { isEnabled: false });
+
+      const beforeHistory = await db.getAlertHistory(alert.id);
+      await service.checkAlerts();
+      const afterHistory = await db.getAlertHistory(alert.id);
+
+      expect(afterHistory.length).toBe(beforeHistory.length);
+    });
+
+    it('records trigger history', async () => {
+      const card = await createTestCard(200);
+      const alert = await db.createPriceAlert(userId, {
+        cardId: card.id,
+        type: 'above',
+        thresholdHigh: 100,
+      });
+
+      await service.checkAlerts();
+
+      const history = await db.getAlertHistory(alert.id);
+      expect(history.length).toBeGreaterThanOrEqual(1);
+      expect(history[0].type).toBe('above');
+      expect(history[0].threshold).toBe(100);
+    });
+
+    it('updates triggerCount on the alert', async () => {
+      const card = await createTestCard(300);
+      const alert = await db.createPriceAlert(userId, {
+        cardId: card.id,
+        type: 'above',
+        thresholdHigh: 50,
+      });
+
+      await service.checkAlerts();
+      const updated = await db.getPriceAlert(alert.id);
+      expect(updated!.triggerCount).toBeGreaterThanOrEqual(1);
+      expect(updated!.lastTriggeredAt).not.toBeNull();
+    });
+  });
+
+  describe('start/stop', () => {
+    it('starts and stops without error', () => {
+      service.start(60000);
+      service.stop();
+    });
+  });
+});

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -1,7 +1,7 @@
 import BetterSqlite3 from 'better-sqlite3';
 import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { eq, and, like, desc, asc, sql, count, lt, lte, inArray } from 'drizzle-orm';
-import { Card, CardInput, User, UserInput, Collection, CollectionInput, CollectionStats, Job, JobInput, JobStatus, AuditLogEntry, AuditLogInput, AuditLogQuery, GradingSubmission, GradingSubmissionInput, GradingStatus, GradingStats, CompReport, CompSale, CompSource, CompResult, StoredCompReport, PopulationData, EbayExportDraft, EbayExportCardSummary, ImageUpload, StorageLocation } from './types';
+import { Card, CardInput, User, UserInput, Collection, CollectionInput, CollectionStats, Job, JobInput, JobStatus, AuditLogEntry, AuditLogInput, AuditLogQuery, GradingSubmission, GradingSubmissionInput, GradingStatus, GradingStats, CompReport, CompSale, CompSource, CompResult, StoredCompReport, PopulationData, EbayExportDraft, EbayExportCardSummary, ImageUpload, StorageLocation, PriceAlert, PriceAlertInput, PriceAlertHistoryEntry } from './types';
 import { v4 as uuidv4 } from 'uuid';
 import bcrypt from 'bcryptjs';
 import * as schema from './db/schema';
@@ -10,7 +10,7 @@ import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
 
-const { users, collections, cards, jobs, gradingSubmissions, auditLogs, compCache, cardCompReports, cardCompSources, popReportSnapshots, cardValueSnapshots, ebayExportDrafts, cardImageUploads } = schema;
+const { users, collections, cards, jobs, gradingSubmissions, auditLogs, compCache, cardCompReports, cardCompSources, popReportSnapshots, cardValueSnapshots, ebayExportDrafts, cardImageUploads, priceAlerts, priceAlertHistory } = schema;
 
 // Baseline SQL executed for in-memory databases (no migration journal needed)
 const BASELINE_SQL = `
@@ -229,6 +229,42 @@ CREATE TABLE IF NOT EXISTS ebay_export_drafts (
   createdAt text NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_ebay_drafts_generatedAt ON ebay_export_drafts (generatedAt);
+
+CREATE TABLE IF NOT EXISTS price_alerts (
+  id text PRIMARY KEY NOT NULL,
+  cardId text NOT NULL,
+  userId text NOT NULL,
+  type text NOT NULL,
+  thresholdLow real,
+  thresholdHigh real,
+  isEnabled integer DEFAULT 1,
+  lastCheckedAt text,
+  lastTriggeredAt text,
+  triggerCount integer DEFAULT 0,
+  createdAt text NOT NULL,
+  updatedAt text NOT NULL,
+  FOREIGN KEY (cardId) REFERENCES cards(id) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (userId) REFERENCES users(id) ON UPDATE no action ON DELETE no action
+);
+CREATE INDEX IF NOT EXISTS idx_price_alerts_cardId ON price_alerts (cardId);
+CREATE INDEX IF NOT EXISTS idx_price_alerts_userId ON price_alerts (userId);
+CREATE INDEX IF NOT EXISTS idx_price_alerts_isEnabled ON price_alerts (isEnabled);
+
+CREATE TABLE IF NOT EXISTS price_alert_history (
+  id text PRIMARY KEY NOT NULL,
+  alertId text NOT NULL,
+  cardId text NOT NULL,
+  previousValue real NOT NULL,
+  currentValue real NOT NULL,
+  threshold real NOT NULL,
+  type text NOT NULL,
+  createdAt text NOT NULL,
+  FOREIGN KEY (alertId) REFERENCES price_alerts(id) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (cardId) REFERENCES cards(id) ON UPDATE no action ON DELETE no action
+);
+CREATE INDEX IF NOT EXISTS idx_alert_history_alertId ON price_alert_history (alertId);
+CREATE INDEX IF NOT EXISTS idx_alert_history_cardId ON price_alert_history (cardId);
+CREATE INDEX IF NOT EXISTS idx_alert_history_createdAt ON price_alert_history (createdAt);
 
 `;
 
@@ -1822,6 +1858,160 @@ class Database {
     const [{ synced }] = this.db.select({ synced: count() }).from(cardImageUploads).all();
 
     return { total: totalImages, synced, unsynced: Math.max(0, totalImages - synced) };
+  }
+
+  // ─── Price Alerts ─────────────────────────────────────────────────────────
+
+  public async createPriceAlert(userId: string, input: PriceAlertInput): Promise<PriceAlert> {
+    const id = uuidv4();
+    const now = new Date().toISOString();
+
+    const alert: PriceAlert = {
+      id,
+      cardId: input.cardId,
+      userId,
+      type: input.type,
+      thresholdLow: input.thresholdLow ?? null,
+      thresholdHigh: input.thresholdHigh ?? null,
+      isEnabled: true,
+      lastCheckedAt: null,
+      lastTriggeredAt: null,
+      triggerCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.db.insert(priceAlerts).values(alert).run();
+    return alert;
+  }
+
+  public async getPriceAlertsByCard(cardId: string): Promise<PriceAlert[]> {
+    return this.db.select().from(priceAlerts)
+      .where(eq(priceAlerts.cardId, cardId))
+      .orderBy(desc(priceAlerts.createdAt))
+      .all() as PriceAlert[];
+  }
+
+  public async getPriceAlertsByUser(userId: string): Promise<PriceAlert[]> {
+    return this.db.select().from(priceAlerts)
+      .where(eq(priceAlerts.userId, userId))
+      .orderBy(desc(priceAlerts.createdAt))
+      .all() as PriceAlert[];
+  }
+
+  public async getPriceAlert(id: string): Promise<PriceAlert | null> {
+    const rows = this.db.select().from(priceAlerts)
+      .where(eq(priceAlerts.id, id))
+      .all() as PriceAlert[];
+    return rows[0] || null;
+  }
+
+  public async updatePriceAlert(id: string, updates: Partial<Pick<PriceAlert, 'type' | 'thresholdLow' | 'thresholdHigh' | 'isEnabled'>>): Promise<PriceAlert | null> {
+    const now = new Date().toISOString();
+    this.db.update(priceAlerts)
+      .set({ ...updates, updatedAt: now })
+      .where(eq(priceAlerts.id, id))
+      .run();
+    return this.getPriceAlert(id);
+  }
+
+  public async deletePriceAlert(id: string): Promise<boolean> {
+    const result = this.db.delete(priceAlerts)
+      .where(eq(priceAlerts.id, id))
+      .run();
+    return result.changes > 0;
+  }
+
+  public async getEnabledAlerts(): Promise<(PriceAlert & { currentValue: number; player: string })[]> {
+    const rows = this.db.select({
+      id: priceAlerts.id,
+      cardId: priceAlerts.cardId,
+      userId: priceAlerts.userId,
+      type: priceAlerts.type,
+      thresholdLow: priceAlerts.thresholdLow,
+      thresholdHigh: priceAlerts.thresholdHigh,
+      isEnabled: priceAlerts.isEnabled,
+      lastCheckedAt: priceAlerts.lastCheckedAt,
+      lastTriggeredAt: priceAlerts.lastTriggeredAt,
+      triggerCount: priceAlerts.triggerCount,
+      createdAt: priceAlerts.createdAt,
+      updatedAt: priceAlerts.updatedAt,
+      currentValue: cards.currentValue,
+      player: cards.player,
+    })
+      .from(priceAlerts)
+      .innerJoin(cards, eq(priceAlerts.cardId, cards.id))
+      .where(eq(priceAlerts.isEnabled, true))
+      .all();
+    return rows as (PriceAlert & { currentValue: number; player: string })[];
+  }
+
+  public async recordAlertTrigger(alertId: string, cardId: string, previousValue: number, currentValue: number, threshold: number, type: 'above' | 'below'): Promise<PriceAlertHistoryEntry> {
+    const id = uuidv4();
+    const now = new Date().toISOString();
+
+    const entry: PriceAlertHistoryEntry = {
+      id,
+      alertId,
+      cardId,
+      previousValue,
+      currentValue,
+      threshold,
+      type,
+      createdAt: now,
+    };
+
+    this.db.insert(priceAlertHistory).values(entry).run();
+
+    // Update the alert's lastTriggeredAt and triggerCount
+    this.db.update(priceAlerts)
+      .set({
+        lastTriggeredAt: now,
+        lastCheckedAt: now,
+        triggerCount: sql`${priceAlerts.triggerCount} + 1`,
+        updatedAt: now,
+      })
+      .where(eq(priceAlerts.id, alertId))
+      .run();
+
+    return entry;
+  }
+
+  public async recordAlertCheck(alertId: string): Promise<void> {
+    const now = new Date().toISOString();
+    this.db.update(priceAlerts)
+      .set({ lastCheckedAt: now, updatedAt: now })
+      .where(eq(priceAlerts.id, alertId))
+      .run();
+  }
+
+  public async getAlertHistory(alertId: string): Promise<PriceAlertHistoryEntry[]> {
+    return this.db.select().from(priceAlertHistory)
+      .where(eq(priceAlertHistory.alertId, alertId))
+      .orderBy(desc(priceAlertHistory.createdAt))
+      .all() as PriceAlertHistoryEntry[];
+  }
+
+  public async getRecentAlertHistory(userId: string, limit: number = 50): Promise<(PriceAlertHistoryEntry & { player: string })[]> {
+    const rows = this.db.select({
+      id: priceAlertHistory.id,
+      alertId: priceAlertHistory.alertId,
+      cardId: priceAlertHistory.cardId,
+      previousValue: priceAlertHistory.previousValue,
+      currentValue: priceAlertHistory.currentValue,
+      threshold: priceAlertHistory.threshold,
+      type: priceAlertHistory.type,
+      createdAt: priceAlertHistory.createdAt,
+      player: cards.player,
+    })
+      .from(priceAlertHistory)
+      .innerJoin(priceAlerts, eq(priceAlertHistory.alertId, priceAlerts.id))
+      .innerJoin(cards, eq(priceAlertHistory.cardId, cards.id))
+      .where(eq(priceAlerts.userId, userId))
+      .orderBy(desc(priceAlertHistory.createdAt))
+      .limit(limit)
+      .all();
+    return rows as (PriceAlertHistoryEntry & { player: string })[];
   }
 
   // ─── Lifecycle ───────────────────────────────────────────────────────────────

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -248,3 +248,39 @@ export const cardValueSnapshots = sqliteTable('card_value_snapshots', {
   index('idx_value_snapshots_snapshotAt').on(table.snapshotAt),
   index('idx_value_snapshots_cardId_snapshotAt').on(table.cardId, table.snapshotAt),
 ]);
+
+// ─── Price Alerts ─────────────────────────────────────────────────────────
+
+export const priceAlerts = sqliteTable('price_alerts', {
+  id: text('id').primaryKey(),
+  cardId: text('cardId').notNull().references(() => cards.id, { onDelete: 'cascade' }),
+  userId: text('userId').notNull().references(() => users.id),
+  type: text('type').notNull().$type<'above' | 'below'>(),
+  thresholdLow: real('thresholdLow'),
+  thresholdHigh: real('thresholdHigh'),
+  isEnabled: integer('isEnabled', { mode: 'boolean' }).default(true),
+  lastCheckedAt: text('lastCheckedAt'),
+  lastTriggeredAt: text('lastTriggeredAt'),
+  triggerCount: integer('triggerCount').default(0),
+  createdAt: text('createdAt').notNull(),
+  updatedAt: text('updatedAt').notNull(),
+}, (table) => [
+  index('idx_price_alerts_cardId').on(table.cardId),
+  index('idx_price_alerts_userId').on(table.userId),
+  index('idx_price_alerts_isEnabled').on(table.isEnabled),
+]);
+
+export const priceAlertHistory = sqliteTable('price_alert_history', {
+  id: text('id').primaryKey(),
+  alertId: text('alertId').notNull().references(() => priceAlerts.id, { onDelete: 'cascade' }),
+  cardId: text('cardId').notNull().references(() => cards.id),
+  previousValue: real('previousValue').notNull(),
+  currentValue: real('currentValue').notNull(),
+  threshold: real('threshold').notNull(),
+  type: text('type').notNull().$type<'above' | 'below'>(),
+  createdAt: text('createdAt').notNull(),
+}, (table) => [
+  index('idx_alert_history_alertId').on(table.alertId),
+  index('idx_alert_history_cardId').on(table.cardId),
+  index('idx_alert_history_createdAt').on(table.createdAt),
+]);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -38,6 +38,8 @@ import { createCollectionRoutes } from './routes/collections';
 import { createAdminUserRoutes } from './routes/adminUsers';
 import { createGradingSubmissionRoutes } from './routes/gradingSubmissions';
 import { createStorageRoutes } from './routes/storage';
+import { createPriceAlertRoutes } from './routes/priceAlerts';
+import PriceAlertService from './services/priceAlertService';
 import { EbayExportOptions, ScpUploadPayload } from './types';
 
 dotenv.config();
@@ -72,6 +74,7 @@ const auditService = new AuditService(db);
 const imageProcessingService = new ImageProcessingService(fileService, db, visionService, imageCropService, auditService);
 const ebayExportService = new EbayExportService(db, fileService);
 const scpUploadService = new ScpUploadService(db, fileService, config);
+const priceAlertService = new PriceAlertService(db, eventService);
 
 // Create Express app
 const app = express();
@@ -101,6 +104,7 @@ app.use('/api/collections', createCollectionRoutes(db, auditService));
 app.use('/api/admin/users', createAdminUserRoutes(db, auditService));
 app.use('/api/grading-submissions', createGradingSubmissionRoutes(db, auditService));
 app.use('/api/storage', createStorageRoutes(db, auditService));
+app.use('/api/price-alerts', createPriceAlertRoutes(db, auditService, priceAlertService));
 
 // Error handling
 app.use(errorHandler);
@@ -194,6 +198,9 @@ if (require.main === module) {
       jobService.start(config.jobPollInterval);
       console.log('Job service started');
 
+      priceAlertService.start();
+      console.log('Price alert service started (hourly checks)');
+
       eventService.startHeartbeat();
 
       const server = app.listen(config.port, '0.0.0.0', () => {
@@ -204,6 +211,7 @@ if (require.main === module) {
       const shutdown = () => {
         console.log('Shutting down...');
         jobService.stop();
+        priceAlertService.stop();
         eventService.stopHeartbeat();
         server.close(async () => {
           if (browserService) {

--- a/server/src/routes/priceAlerts.ts
+++ b/server/src/routes/priceAlerts.ts
@@ -1,0 +1,205 @@
+import { Router, Response } from 'express';
+import Database from '../database';
+import AuditService from '../services/auditService';
+import PriceAlertService from '../services/priceAlertService';
+import { AuthenticatedRequest, PriceAlertInput } from '../types';
+
+export function createPriceAlertRoutes(
+  db: Database,
+  auditService: AuditService,
+  priceAlertService: PriceAlertService
+): Router {
+  const router = Router();
+
+  // Get alerts for the authenticated user
+  router.get('/', async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = req.user?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Not authenticated' });
+        return;
+      }
+      const alerts = await db.getPriceAlertsByUser(userId);
+      res.json(alerts);
+    } catch (error) {
+      console.error('Error getting price alerts:', error);
+      res.status(500).json({ error: 'Failed to fetch price alerts' });
+    }
+  });
+
+  // Get alerts for a specific card
+  router.get('/card/:cardId', async (req, res: Response) => {
+    try {
+      const alerts = await db.getPriceAlertsByCard(req.params.cardId);
+      res.json(alerts);
+    } catch (error) {
+      console.error('Error getting card alerts:', error);
+      res.status(500).json({ error: 'Failed to fetch card alerts' });
+    }
+  });
+
+  // Get recent alert history for the authenticated user
+  router.get('/history', async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = req.user?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Not authenticated' });
+        return;
+      }
+      const limit = parseInt(req.query.limit as string) || 50;
+      const history = await db.getRecentAlertHistory(userId, limit);
+      res.json(history);
+    } catch (error) {
+      console.error('Error getting alert history:', error);
+      res.status(500).json({ error: 'Failed to fetch alert history' });
+    }
+  });
+
+  // Get history for a specific alert
+  router.get('/:id/history', async (req, res: Response) => {
+    try {
+      const history = await db.getAlertHistory(req.params.id);
+      res.json(history);
+    } catch (error) {
+      console.error('Error getting alert history:', error);
+      res.status(500).json({ error: 'Failed to fetch alert history' });
+    }
+  });
+
+  // Create a new price alert
+  router.post('/', async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = req.user?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Not authenticated' });
+        return;
+      }
+
+      const input: PriceAlertInput = req.body;
+      if (!input.cardId || !input.type) {
+        res.status(400).json({ error: 'cardId and type are required' });
+        return;
+      }
+
+      if (!['above', 'below'].includes(input.type)) {
+        res.status(400).json({ error: 'type must be "above" or "below"' });
+        return;
+      }
+
+      if (input.type === 'above' && (input.thresholdHigh === undefined || input.thresholdHigh === null)) {
+        res.status(400).json({ error: 'thresholdHigh is required for "above" alerts' });
+        return;
+      }
+
+      if (input.type === 'below' && (input.thresholdLow === undefined || input.thresholdLow === null)) {
+        res.status(400).json({ error: 'thresholdLow is required for "below" alerts' });
+        return;
+      }
+
+      const alert = await db.createPriceAlert(userId, input);
+
+      auditService.log(req, {
+        action: 'price_alert.create',
+        entity: 'price_alert',
+        entityId: alert.id,
+        details: { cardId: input.cardId, type: input.type },
+      });
+
+      res.status(201).json(alert);
+    } catch (error) {
+      console.error('Error creating price alert:', error);
+      res.status(500).json({ error: 'Failed to create price alert' });
+    }
+  });
+
+  // Update a price alert
+  router.put('/:id', async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = req.user?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Not authenticated' });
+        return;
+      }
+
+      const existing = await db.getPriceAlert(req.params.id);
+      if (!existing) {
+        res.status(404).json({ error: 'Alert not found' });
+        return;
+      }
+
+      if (existing.userId !== userId) {
+        res.status(403).json({ error: 'Not authorized' });
+        return;
+      }
+
+      const alert = await db.updatePriceAlert(req.params.id, req.body);
+
+      auditService.log(req, {
+        action: 'price_alert.update',
+        entity: 'price_alert',
+        entityId: req.params.id,
+        details: req.body,
+      });
+
+      res.json(alert);
+    } catch (error) {
+      console.error('Error updating price alert:', error);
+      res.status(500).json({ error: 'Failed to update price alert' });
+    }
+  });
+
+  // Delete a price alert
+  router.delete('/:id', async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = req.user?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Not authenticated' });
+        return;
+      }
+
+      const existing = await db.getPriceAlert(req.params.id);
+      if (!existing) {
+        res.status(404).json({ error: 'Alert not found' });
+        return;
+      }
+
+      if (existing.userId !== userId) {
+        res.status(403).json({ error: 'Not authorized' });
+        return;
+      }
+
+      await db.deletePriceAlert(req.params.id);
+
+      auditService.log(req, {
+        action: 'price_alert.delete',
+        entity: 'price_alert',
+        entityId: req.params.id,
+        details: { cardId: existing.cardId },
+      });
+
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error deleting price alert:', error);
+      res.status(500).json({ error: 'Failed to delete price alert' });
+    }
+  });
+
+  // Manually trigger alert check
+  router.post('/check', async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = req.user?.userId;
+      if (!userId) {
+        res.status(401).json({ error: 'Not authenticated' });
+        return;
+      }
+
+      const result = await priceAlertService.checkAlerts();
+      res.json(result);
+    } catch (error) {
+      console.error('Error checking alerts:', error);
+      res.status(500).json({ error: 'Failed to check alerts' });
+    }
+  });
+
+  return router;
+}

--- a/server/src/services/priceAlertService.ts
+++ b/server/src/services/priceAlertService.ts
@@ -1,0 +1,83 @@
+import Database from '../database';
+import EventService from './eventService';
+import { PriceAlert } from '../types';
+
+class PriceAlertService {
+  private db: Database;
+  private eventService: EventService;
+  private checkInterval: ReturnType<typeof setInterval> | null = null;
+
+  constructor(db: Database, eventService: EventService) {
+    this.db = db;
+    this.eventService = eventService;
+  }
+
+  async checkAlerts(): Promise<{ triggered: number; checked: number }> {
+    const alerts = await this.db.getEnabledAlerts();
+    let triggered = 0;
+
+    for (const alert of alerts) {
+      const { currentValue } = alert;
+      let shouldTrigger = false;
+      let threshold = 0;
+
+      if (alert.type === 'above' && alert.thresholdHigh !== null && currentValue >= alert.thresholdHigh) {
+        shouldTrigger = true;
+        threshold = alert.thresholdHigh;
+      } else if (alert.type === 'below' && alert.thresholdLow !== null && currentValue <= alert.thresholdLow) {
+        shouldTrigger = true;
+        threshold = alert.thresholdLow;
+      }
+
+      if (shouldTrigger) {
+        // Use previous value from last check, or threshold as fallback
+        const previousValue = await this.getPreviousValue(alert);
+        await this.db.recordAlertTrigger(
+          alert.id, alert.cardId, previousValue, currentValue, threshold, alert.type
+        );
+        triggered++;
+
+        this.eventService.broadcast('price-alert', {
+          alertId: alert.id,
+          cardId: alert.cardId,
+          player: alert.player,
+          type: alert.type,
+          threshold,
+          currentValue,
+          previousValue,
+        });
+      } else {
+        await this.db.recordAlertCheck(alert.id);
+      }
+    }
+
+    return { triggered, checked: alerts.length };
+  }
+
+  private async getPreviousValue(alert: PriceAlert & { currentValue: number }): Promise<number> {
+    const history = await this.db.getAlertHistory(alert.id);
+    if (history.length > 0) {
+      return history[0].currentValue;
+    }
+    // First trigger — no previous history, use current value as a reasonable default
+    return alert.currentValue;
+  }
+
+  start(intervalMs: number = 3600000): void {
+    this.stop();
+    this.checkInterval = setInterval(() => {
+      this.checkAlerts().catch(err => {
+        console.error('Price alert check failed:', err);
+      });
+    }, intervalMs);
+  }
+
+  stop(): void {
+    if (this.checkInterval) {
+      clearInterval(this.checkInterval);
+      this.checkInterval = null;
+    }
+  }
+}
+
+export default PriceAlertService;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -482,6 +482,43 @@ export interface GradingStats {
   avgGrade: number | null;
 }
 
+// ─── Price Alerts ────────────────────────────────────────────────────────────
+
+export type PriceAlertType = 'above' | 'below';
+
+export interface PriceAlert {
+  id: string;
+  cardId: string;
+  userId: string;
+  type: PriceAlertType;
+  thresholdLow: number | null;
+  thresholdHigh: number | null;
+  isEnabled: boolean;
+  lastCheckedAt: string | null;
+  lastTriggeredAt: string | null;
+  triggerCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PriceAlertInput {
+  cardId: string;
+  type: PriceAlertType;
+  thresholdLow?: number;
+  thresholdHigh?: number;
+}
+
+export interface PriceAlertHistoryEntry {
+  id: string;
+  alertId: string;
+  cardId: string;
+  previousValue: number;
+  currentValue: number;
+  threshold: number;
+  type: PriceAlertType;
+  createdAt: string;
+}
+
 // ─── Audit Log ──────────────────────────────────────────────────────────────
 
 export interface AuditLogEntry {
@@ -566,6 +603,9 @@ export interface AuditDetailsMap {
   'grading.delete': { submissionId: string; cardId: string };
   'storage.update': { cardId: string; location: StorageLocation };
   'storage.bulk_assign': { cardIds: string[]; location: StorageLocation };
+  'price_alert.create': { cardId: string; type: string };
+  'price_alert.update': Record<string, unknown>;
+  'price_alert.delete': { cardId: string };
 }
 
 export type AuditAction = keyof AuditDetailsMap;

--- a/src/components/AlertNotifications/AlertNotifications.css
+++ b/src/components/AlertNotifications/AlertNotifications.css
@@ -1,0 +1,115 @@
+.alert-notifications {
+  position: relative;
+}
+
+.alert-bell {
+  position: relative;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 6px;
+  color: var(--text-primary, #374151);
+  display: flex;
+  align-items: center;
+}
+
+.alert-bell:hover {
+  color: var(--primary-color, #4f46e5);
+}
+
+.alert-badge {
+  position: absolute;
+  top: 0;
+  right: -2px;
+  background: #dc2626;
+  color: white;
+  font-size: 0.65rem;
+  font-weight: 600;
+  min-width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 3px;
+}
+
+.alert-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  width: 320px;
+  max-height: 400px;
+  background: var(--bg-primary, #fff);
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+  overflow: hidden;
+}
+
+.alert-dropdown-header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.alert-dropdown-list {
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.alert-empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.85rem;
+}
+
+.alert-history-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border-color, #f3f4f6);
+}
+
+.alert-history-item:last-child {
+  border-bottom: none;
+}
+
+.alert-history-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.alert-history-player {
+  font-weight: 500;
+  font-size: 0.85rem;
+}
+
+.alert-history-type {
+  font-size: 0.8rem;
+}
+
+.alert-history-type.above {
+  color: #166534;
+}
+
+.alert-history-type.below {
+  color: #991b1b;
+}
+
+.alert-history-value {
+  font-size: 0.75rem;
+  color: var(--text-secondary, #6b7280);
+}
+
+.alert-history-time {
+  font-size: 0.75rem;
+  color: var(--text-secondary, #9ca3af);
+  white-space: nowrap;
+  margin-left: 8px;
+}

--- a/src/components/AlertNotifications/AlertNotifications.tsx
+++ b/src/components/AlertNotifications/AlertNotifications.tsx
@@ -1,0 +1,120 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { PriceAlertHistoryEntry } from '../../types';
+import apiService from '../../services/api';
+import { useSSE } from '../../hooks/useSSE';
+import './AlertNotifications.css';
+
+const AlertNotifications: React.FC = () => {
+  const [history, setHistory] = useState<(PriceAlertHistoryEntry & { player: string })[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const lastSeenRef = useRef<string | null>(null);
+  const sse = useSSE(true);
+
+  const loadHistory = useCallback(async () => {
+    try {
+      const data = await apiService.getPriceAlertHistory();
+      setHistory(data);
+
+      const lastSeen = lastSeenRef.current || localStorage.getItem('lastSeenAlert');
+      if (lastSeen) {
+        const unread = data.filter(h => h.createdAt > lastSeen).length;
+        setUnreadCount(unread);
+      } else if (data.length > 0) {
+        setUnreadCount(data.length);
+      }
+    } catch {
+      // Silently fail — alerts are non-critical
+    }
+  }, []);
+
+  useEffect(() => {
+    loadHistory();
+  }, [loadHistory]);
+
+  useEffect(() => {
+    const unsub = sse.on('price-alert', () => {
+      loadHistory();
+    });
+    return unsub;
+  }, [sse, loadHistory]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  const handleOpen = () => {
+    setIsOpen(!isOpen);
+    if (!isOpen && history.length > 0) {
+      const latest = history[0].createdAt;
+      lastSeenRef.current = latest;
+      localStorage.setItem('lastSeenAlert', latest);
+      setUnreadCount(0);
+    }
+  };
+
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
+
+  const timeAgo = (dateStr: string) => {
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  };
+
+  return (
+    <div ref={ref} className="alert-notifications">
+      <button className="alert-bell" onClick={handleOpen} title="Price Alerts">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+          <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+        </svg>
+        {unreadCount > 0 && (
+          <span className="alert-badge">{unreadCount > 9 ? '9+' : unreadCount}</span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="alert-dropdown">
+          <div className="alert-dropdown-header">
+            <span>Price Alerts</span>
+          </div>
+          <div className="alert-dropdown-list">
+            {history.length === 0 ? (
+              <div className="alert-empty">No alert history yet.</div>
+            ) : (
+              history.slice(0, 20).map(entry => (
+                <div key={entry.id} className="alert-history-item">
+                  <div className="alert-history-info">
+                    <span className="alert-history-player">{entry.player}</span>
+                    <span className={`alert-history-type ${entry.type}`}>
+                      {entry.type === 'above' ? 'rose above' : 'dropped below'} {formatCurrency(entry.threshold)}
+                    </span>
+                    <span className="alert-history-value">
+                      Now: {formatCurrency(entry.currentValue)}
+                    </span>
+                  </div>
+                  <span className="alert-history-time">{timeAgo(entry.createdAt)}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AlertNotifications;

--- a/src/components/CardDetail/CardDetail.tsx
+++ b/src/components/CardDetail/CardDetail.tsx
@@ -4,6 +4,7 @@ import { exportDetailedCardReport } from '../../utils/pdfExport';
 import { EbayListingPreview } from '../EbayListing/EbayListingPreview';
 import { BreakEvenCalculator } from '../BreakEvenCalculator/BreakEvenCalculator';
 import { GradingRoiAnalyzer } from '../GradingRoiAnalyzer/GradingRoiAnalyzer';
+import PriceAlertModal from '../PriceAlertModal/PriceAlertModal';
 import './CardDetail.css';
 
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000/api';
@@ -23,6 +24,7 @@ const CardDetail: React.FC<CardDetailProps> = ({ card, onEdit, onClose }) => {
   const [showEbayListing, setShowEbayListing] = useState(false);
   const [showBreakEven, setShowBreakEven] = useState(false);
   const [showGradingRoi, setShowGradingRoi] = useState(false);
+  const [showPriceAlerts, setShowPriceAlerts] = useState(false);
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('en-US', {
@@ -75,6 +77,9 @@ const CardDetail: React.FC<CardDetailProps> = ({ card, onEdit, onClose }) => {
             </button>
             <button onClick={() => setShowEbayListing(true)} className="ebay-listing-btn" title="Generate eBay Listing">
               🛒 eBay
+            </button>
+            <button onClick={() => setShowPriceAlerts(true)} className="price-alert-btn" title="Price Alerts">
+              Alerts
             </button>
             <button onClick={() => setShowBreakEven(true)} className="break-even-btn" title="Break-Even Calculator">
               Break-Even
@@ -255,6 +260,12 @@ const CardDetail: React.FC<CardDetailProps> = ({ card, onEdit, onClose }) => {
         <GradingRoiAnalyzer
           card={card}
           onClose={() => setShowGradingRoi(false)}
+        />
+      )}
+      {showPriceAlerts && (
+        <PriceAlertModal
+          card={card}
+          onClose={() => setShowPriceAlerts(false)}
         />
       )}
     </div>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../../context/AuthContext';
 import { useCards } from '../../context/ApiCardContext';
 import { exportCardsAsJSON, exportCardsAsCSV } from '../../utils/exportUtils';
 import { exportCardsToPDF } from '../../utils/pdfExport';
+import AlertNotifications from '../AlertNotifications/AlertNotifications';
 import './Layout.css';
 
 type View = 'dashboard' | 'inventory' | 'add-card' | 'holding-pen' | 'processed' | 'admin' | 'profile' | 'reports' | 'ebay' | 'backup' | 'users' | 'collections' | 'about' | 'audit-log' | 'grading' | 'grading-roi' | 'heatmap' | 'storage';
@@ -204,6 +205,8 @@ const Layout: React.FC<LayoutProps> = ({ children, currentView, onViewChange }) 
               </span>
             </div>
             
+            <AlertNotifications />
+
             <div className="export-menu">
               <button className="export-btn">
                 Export

--- a/src/components/PriceAlertModal/PriceAlertModal.css
+++ b/src/components/PriceAlertModal/PriceAlertModal.css
@@ -1,0 +1,225 @@
+.price-alert-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.price-alert-modal {
+  background: var(--bg-primary, #fff);
+  border-radius: 8px;
+  width: 420px;
+  max-width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+}
+
+.price-alert-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+
+.price-alert-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.price-alert-header .close-btn {
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  cursor: pointer;
+  color: var(--text-secondary, #6b7280);
+  padding: 0 4px;
+}
+
+.price-alert-card-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 20px;
+  background: var(--bg-secondary, #f9fafb);
+  font-size: 0.9rem;
+}
+
+.price-alert-card-info .card-name {
+  font-weight: 500;
+}
+
+.price-alert-card-info .current-value {
+  color: var(--text-secondary, #6b7280);
+}
+
+.price-alert-form {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+
+.price-alert-form .form-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.price-alert-form select {
+  flex: 0 0 auto;
+  padding: 8px;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.price-alert-form .threshold-input {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.price-alert-form .currency-prefix {
+  padding: 8px;
+  background: var(--bg-secondary, #f3f4f6);
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.85rem;
+}
+
+.price-alert-form .threshold-input input {
+  flex: 1;
+  border: none;
+  padding: 8px;
+  font-size: 0.85rem;
+  outline: none;
+  min-width: 60px;
+}
+
+.price-alert-form button[type="submit"] {
+  flex: 0 0 auto;
+  padding: 8px 16px;
+  background: var(--primary-color, #4f46e5);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.price-alert-form button[type="submit"]:hover {
+  opacity: 0.9;
+}
+
+.price-alert-form button[type="submit"]:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.alert-error {
+  padding: 8px 20px;
+  color: #dc2626;
+  font-size: 0.85rem;
+}
+
+.alerts-list {
+  padding: 12px 20px 20px;
+}
+
+.alerts-list .loading,
+.alerts-list .empty {
+  text-align: center;
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.85rem;
+  padding: 16px 0;
+}
+
+.alert-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 6px;
+  margin-bottom: 8px;
+}
+
+.alert-item.disabled {
+  opacity: 0.5;
+}
+
+.alert-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.alert-type {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.alert-type.above {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.alert-type.below {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.alert-threshold {
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.trigger-count {
+  font-size: 0.75rem;
+  color: var(--text-secondary, #6b7280);
+}
+
+.alert-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.alert-actions .toggle-btn {
+  padding: 4px 10px;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 4px;
+  background: var(--bg-secondary, #f3f4f6);
+  cursor: pointer;
+  font-size: 0.75rem;
+}
+
+.alert-actions .toggle-btn.enabled {
+  background: #dcfce7;
+  border-color: #86efac;
+  color: #166534;
+}
+
+.alert-actions .delete-btn {
+  padding: 4px 8px;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+  color: #dc2626;
+  font-size: 1rem;
+}
+
+.alert-actions .delete-btn:hover {
+  background: #fef2f2;
+}

--- a/src/components/PriceAlertModal/PriceAlertModal.tsx
+++ b/src/components/PriceAlertModal/PriceAlertModal.tsx
@@ -1,0 +1,164 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Card, PriceAlert, PriceAlertType } from '../../types';
+import apiService from '../../services/api';
+import './PriceAlertModal.css';
+
+interface PriceAlertModalProps {
+  card: Card;
+  onClose: () => void;
+}
+
+const PriceAlertModal: React.FC<PriceAlertModalProps> = ({ card, onClose }) => {
+  const [alerts, setAlerts] = useState<PriceAlert[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [type, setType] = useState<PriceAlertType>('above');
+  const [threshold, setThreshold] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const loadAlerts = useCallback(async () => {
+    try {
+      const data = await apiService.getPriceAlertsByCard(card.id);
+      setAlerts(data);
+    } catch {
+      setError('Failed to load alerts');
+    } finally {
+      setLoading(false);
+    }
+  }, [card.id]);
+
+  useEffect(() => {
+    loadAlerts();
+  }, [loadAlerts]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const value = parseFloat(threshold);
+    if (isNaN(value) || value <= 0) {
+      setError('Enter a valid threshold amount');
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+    try {
+      await apiService.createPriceAlert({
+        cardId: card.id,
+        type,
+        ...(type === 'above' ? { thresholdHigh: value } : { thresholdLow: value }),
+      });
+      setThreshold('');
+      await loadAlerts();
+    } catch {
+      setError('Failed to create alert');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = async (alert: PriceAlert) => {
+    try {
+      await apiService.updatePriceAlert(alert.id, { isEnabled: !alert.isEnabled });
+      await loadAlerts();
+    } catch {
+      setError('Failed to update alert');
+    }
+  };
+
+  const handleDelete = async (alertId: string) => {
+    try {
+      await apiService.deletePriceAlert(alertId);
+      await loadAlerts();
+    } catch {
+      setError('Failed to delete alert');
+    }
+  };
+
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
+
+  return (
+    <div className="price-alert-modal-overlay" onClick={onClose}>
+      <div className="price-alert-modal" onClick={e => e.stopPropagation()}>
+        <div className="price-alert-header">
+          <h3>Price Alerts</h3>
+          <button onClick={onClose} className="close-btn">&times;</button>
+        </div>
+
+        <div className="price-alert-card-info">
+          <span className="card-name">{card.year} {card.brand} {card.player}</span>
+          <span className="current-value">Current: {formatCurrency(card.currentValue)}</span>
+        </div>
+
+        <form className="price-alert-form" onSubmit={handleCreate}>
+          <div className="form-row">
+            <select value={type} onChange={e => setType(e.target.value as PriceAlertType)}>
+              <option value="above">Alert when above</option>
+              <option value="below">Alert when below</option>
+            </select>
+            <div className="threshold-input">
+              <span className="currency-prefix">$</span>
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="0.00"
+                value={threshold}
+                onChange={e => setThreshold(e.target.value)}
+              />
+            </div>
+            <button type="submit" disabled={saving}>
+              {saving ? 'Adding...' : 'Add'}
+            </button>
+          </div>
+        </form>
+
+        {error && <div className="alert-error">{error}</div>}
+
+        <div className="alerts-list">
+          {loading ? (
+            <div className="loading">Loading alerts...</div>
+          ) : alerts.length === 0 ? (
+            <div className="empty">No alerts configured for this card.</div>
+          ) : (
+            alerts.map(alert => (
+              <div key={alert.id} className={`alert-item ${!alert.isEnabled ? 'disabled' : ''}`}>
+                <div className="alert-info">
+                  <span className={`alert-type ${alert.type}`}>
+                    {alert.type === 'above' ? 'Above' : 'Below'}
+                  </span>
+                  <span className="alert-threshold">
+                    {formatCurrency(alert.type === 'above' ? alert.thresholdHigh! : alert.thresholdLow!)}
+                  </span>
+                  {alert.triggerCount > 0 && (
+                    <span className="trigger-count">
+                      Triggered {alert.triggerCount}x
+                    </span>
+                  )}
+                </div>
+                <div className="alert-actions">
+                  <button
+                    className={`toggle-btn ${alert.isEnabled ? 'enabled' : ''}`}
+                    onClick={() => handleToggle(alert)}
+                    title={alert.isEnabled ? 'Disable' : 'Enable'}
+                  >
+                    {alert.isEnabled ? 'On' : 'Off'}
+                  </button>
+                  <button
+                    className="delete-btn"
+                    onClick={() => handleDelete(alert.id)}
+                    title="Delete alert"
+                  >
+                    &times;
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PriceAlertModal;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,4 @@
-import { Card, User, StorageLocation } from '../types';
+import { Card, User, StorageLocation, PriceAlert, PriceAlertHistoryEntry } from '../types';
 import { logDebug, logInfo, logError } from '../utils/logger';
 
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000/api';
@@ -892,6 +892,36 @@ class ApiService {
       method: 'POST',
       body: JSON.stringify({ cardIds, location }),
     });
+  }
+
+  // ─── Price Alerts ─────────────────────────────────────────────────────
+
+  public async getPriceAlerts(): Promise<PriceAlert[]> {
+    return this.request('/price-alerts');
+  }
+
+  public async getPriceAlertsByCard(cardId: string): Promise<PriceAlert[]> {
+    return this.request(`/price-alerts/card/${cardId}`);
+  }
+
+  public async createPriceAlert(data: { cardId: string; type: 'above' | 'below'; thresholdLow?: number; thresholdHigh?: number }): Promise<PriceAlert> {
+    return this.request('/price-alerts', { method: 'POST', body: JSON.stringify(data) });
+  }
+
+  public async updatePriceAlert(id: string, data: Partial<Pick<PriceAlert, 'type' | 'thresholdLow' | 'thresholdHigh' | 'isEnabled'>>): Promise<PriceAlert> {
+    return this.request(`/price-alerts/${id}`, { method: 'PUT', body: JSON.stringify(data) });
+  }
+
+  public async deletePriceAlert(id: string): Promise<void> {
+    return this.request(`/price-alerts/${id}`, { method: 'DELETE' });
+  }
+
+  public async checkPriceAlerts(): Promise<{ triggered: number; checked: number }> {
+    return this.request('/price-alerts/check', { method: 'POST' });
+  }
+
+  public async getPriceAlertHistory(): Promise<(PriceAlertHistoryEntry & { player: string })[]> {
+    return this.request('/price-alerts/history');
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -313,3 +313,32 @@ export const getGradeScale = (company: string): GradeOption[] => {
 };
 
 export const RAW_CONDITIONS = ['Raw', 'Near Mint', 'Excellent', 'Very Good', 'Good', 'Poor'];
+
+export type PriceAlertType = 'above' | 'below';
+
+export interface PriceAlert {
+  id: string;
+  cardId: string;
+  userId: string;
+  type: PriceAlertType;
+  thresholdLow: number | null;
+  thresholdHigh: number | null;
+  isEnabled: boolean;
+  lastCheckedAt: string | null;
+  lastTriggeredAt: string | null;
+  triggerCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PriceAlertHistoryEntry {
+  id: string;
+  alertId: string;
+  cardId: string;
+  previousValue: number;
+  currentValue: number;
+  threshold: number;
+  type: PriceAlertType;
+  createdAt: string;
+  player?: string;
+}


### PR DESCRIPTION
## Summary

- Add per-card price alerts with configurable above/below thresholds that trigger when card values cross set boundaries
- Backend: migration, Drizzle schema, database CRUD, PriceAlertService with hourly checks, SSE broadcasting, and full REST API
- Frontend: PriceAlertModal for per-card alert config, AlertNotifications bell with unread badge and real-time SSE updates
- 28 new tests covering route CRUD/validation/auth and service trigger logic

Closes #8

## Changes

- **server/drizzle**: Add `price_alerts` and `price_alert_history` tables with migration and journal entry
- **server/src/db/schema.ts**: Drizzle table definitions for both tables
- **server/src/types.ts**: `PriceAlert`, `PriceAlertInput`, `PriceAlertHistoryEntry`, `PriceAlertType`, audit actions
- **server/src/database.ts**: BASELINE_SQL entries, CRUD methods, enabled alert queries with card join, trigger recording, history queries
- **server/src/services/priceAlertService.ts**: Hourly alert check service, compares card `currentValue` against thresholds, SSE broadcast on trigger
- **server/src/routes/priceAlerts.ts**: REST API — GET/POST/PUT/DELETE alerts, GET history, POST manual check
- **server/src/index.ts**: Register routes, instantiate and start/stop PriceAlertService
- **server/src/__tests__**: 21 route tests + 7 service tests
- **src/types/index.ts**: Frontend `PriceAlert` and `PriceAlertHistoryEntry` types
- **src/services/api.ts**: 7 price alert API methods on ApiService
- **src/components/PriceAlertModal**: Modal for creating/toggling/deleting per-card alerts
- **src/components/AlertNotifications**: Bell icon with unread count badge, dropdown history, SSE-powered real-time updates
- **src/components/CardDetail/CardDetail.tsx**: "Alerts" button in card detail actions
- **src/components/Layout/Layout.tsx**: AlertNotifications bell in header

## Test Plan

- [x] Run `cd server && npx jest --testPathPatterns="priceAlert"` — 28 tests pass
- [x] Run `cd server && npx jest` — all 1031 tests pass, no regressions
- [x] Create an above alert on a card, update card value above threshold, trigger manual check — verify SSE notification
- [x] Create a below alert, verify it triggers when value drops below threshold
- [x] Disable an alert, verify it no longer triggers
- [x] Delete an alert, verify it's removed from the card's alert list
- [x] Verify notification bell shows unread count after alerts trigger
- [x] Verify clicking bell marks alerts as read