### PR TITLE
Show average comp price on Processed Cards tiles

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -1453,6 +1453,36 @@ class Database {
     return results;
   }
 
+  public async getPriceSummary(): Promise<{ cardId: string; aggregateAverage: number | null; popAdjustedAverage: number | null; images: string[] }[]> {
+    const rows = this.db
+      .select({
+        cardId: cardCompReports.cardId,
+        aggregateAverage: cardCompReports.aggregateAverage,
+        popAdjustedAverage: cardCompReports.popAdjustedAverage,
+        images: cards.images,
+        generatedAt: cardCompReports.generatedAt,
+      })
+      .from(cardCompReports)
+      .innerJoin(cards, eq(cards.id, cardCompReports.cardId))
+      .orderBy(desc(cardCompReports.generatedAt))
+      .all();
+
+    const seen = new Set<string>();
+    const results: { cardId: string; aggregateAverage: number | null; popAdjustedAverage: number | null; images: string[] }[] = [];
+    for (const row of rows) {
+      if (seen.has(row.cardId)) continue;
+      seen.add(row.cardId);
+      const images = Array.isArray(row.images) ? row.images as string[] : JSON.parse(row.images as string || '[]');
+      results.push({
+        cardId: row.cardId,
+        aggregateAverage: row.aggregateAverage ?? null,
+        popAdjustedAverage: row.popAdjustedAverage ?? null,
+        images,
+      });
+    }
+    return results;
+  }
+
   public async deleteCompReports(cardId: string): Promise<number> {
     const result = this.db.delete(cardCompReports)
       .where(eq(cardCompReports.cardId, cardId))

--- a/server/src/routes/comps.ts
+++ b/server/src/routes/comps.ts
@@ -17,6 +17,17 @@ export function createCompRoutes(db: Database, compService: CompService): Router
     }
   });
 
+  // GET /api/comps/price-summary — returns aggregate comp prices for all cards with stored comp reports
+  router.get('/price-summary', async (_req: Request, res: Response) => {
+    try {
+      const summary = await db.getPriceSummary();
+      res.json(summary);
+    } catch (error) {
+      console.error('Error getting price summary:', error);
+      res.status(500).json({ error: 'Failed to get price summary' });
+    }
+  });
+
   // POST /api/comps/generate
   router.post('/generate', async (req: Request, res: Response) => {
     try {

--- a/src/components/ProcessedGallery/ProcessedGallery.css
+++ b/src/components/ProcessedGallery/ProcessedGallery.css
@@ -325,6 +325,12 @@
   color: var(--text-tertiary);
 }
 
+.processed-gallery-comp-price {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--success, #16a34a);
+}
+
 /* ─── Card Actions ───────────────────────────────────────────────────────── */
 
 .processed-gallery-card-actions {

--- a/src/components/ProcessedGallery/ProcessedGallery.tsx
+++ b/src/components/ProcessedGallery/ProcessedGallery.tsx
@@ -168,8 +168,10 @@ const ProcessedGallery: React.FC = () => {
   const [editSaving, setEditSaving] = useState(false);
   const [compLoadingId, setCompLoadingId] = useState<string | null>(null);
   const [compReport, setCompReport] = useState<CompReport | null>(null);
+  const [compReportPairId, setCompReportPairId] = useState<string | null>(null);
   const [bulkCompLoading, setBulkCompLoading] = useState(false);
   const [popTiers, setPopTiers] = useState<Map<string, PopRarityTier>>(new Map());
+  const [compPrices, setCompPrices] = useState<Map<string, { average: number | null; popAdjusted: number | null }>>(new Map());
   const [moveCards, setMoveCards] = useState<Card[]>([]);
   const [moveLoading, setMoveLoading] = useState(false);
   const [scpUploading, setScpUploading] = useState(false);
@@ -220,6 +222,25 @@ const ProcessedGallery: React.FC = () => {
         }
         if (tiers.size > 0) setPopTiers(tiers);
       } catch { /* pop summary is non-critical */ }
+
+      // Hydrate comp prices from stored comp reports
+      try {
+        const priceSummary = await apiService.getPriceSummary();
+        const prices = new Map<string, { average: number | null; popAdjusted: number | null }>();
+        for (const entry of priceSummary) {
+          for (const img of entry.images) {
+            const ext = '.' + img.split('.').pop();
+            let base = img.slice(0, img.length - ext.length);
+            if (base.endsWith('-front')) base = base.slice(0, -6);
+            else if (base.endsWith('-back')) base = base.slice(0, -5);
+            if (grouped.some(p => p.id === base)) {
+              prices.set(base, { average: entry.aggregateAverage, popAdjusted: entry.popAdjustedAverage });
+              break;
+            }
+          }
+        }
+        if (prices.size > 0) setCompPrices(prices);
+      } catch { /* price summary is non-critical */ }
 
       // Fetch SCP upload status
       try {
@@ -332,6 +353,17 @@ const ProcessedGallery: React.FC = () => {
     }
   }, []);
 
+  const trackCompPrice = useCallback((pairId: string, report: CompReport) => {
+    setCompPrices(prev => {
+      const next = new Map(prev);
+      next.set(pairId, {
+        average: report.aggregateAverage ?? null,
+        popAdjusted: report.popAdjustedAverage ?? null,
+      });
+      return next;
+    });
+  }, []);
+
   const handleGenerateComps = async (pair: CardPair) => {
     const filename = pair.front?.name || pair.back?.name;
     if (!filename) return;
@@ -340,6 +372,8 @@ const ProcessedGallery: React.FC = () => {
       const card = await apiService.getCardByImage(filename);
       const report = await apiService.generateComps(card.id);
       trackPopTier(pair.id, report);
+      trackCompPrice(pair.id, report);
+      setCompReportPairId(pair.id);
       setCompReport(report);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to generate comps');
@@ -613,6 +647,18 @@ const ProcessedGallery: React.FC = () => {
                   {[pair.front, pair.back].filter(Boolean).map(f => (
                     <span key={f!.name} className="processed-gallery-file-size">{formatFileSize(f!.size)}</span>
                   ))}
+                  {(() => {
+                    const price = compPrices.get(pair.id);
+                    if (!price) return null;
+                    const value = price.popAdjusted ?? price.average;
+                    if (value == null) return null;
+                    const label = price.popAdjusted != null ? 'avg (pop-adj)' : 'avg';
+                    return (
+                      <span className="processed-gallery-comp-price" title={label}>
+                        ${value.toFixed(2)} {label}
+                      </span>
+                    );
+                  })()}
                   {popTiers.has(pair.id) && (
                     <span className={`processed-gallery-pop-badge processed-gallery-pop-${popTiers.get(pair.id)}`}>
                       {popTiers.get(pair.id) === 'ultra-low' ? 'Ultra-Low Pop' :
@@ -721,10 +767,14 @@ const ProcessedGallery: React.FC = () => {
       {compReport && (
         <CompReportModal
           report={compReport}
-          onClose={() => setCompReport(null)}
+          onClose={() => { setCompReport(null); setCompReportPairId(null); }}
           onRefresh={async (cardId) => {
             const updated = await apiService.refreshComps(cardId);
             setCompReport(updated);
+            if (compReportPairId) {
+              trackPopTier(compReportPairId, updated);
+              trackCompPrice(compReportPairId, updated);
+            }
             return updated;
           }}
         />

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -576,6 +576,10 @@ class ApiService {
     return this.request<{ cardId: string; rarityTier: PopRarityTier; popAdjustedAverage: number | null; images: string[] }[]>('/comps/pop-summary');
   }
 
+  public async getPriceSummary(): Promise<{ cardId: string; aggregateAverage: number | null; popAdjustedAverage: number | null; images: string[] }[]> {
+    return this.request<{ cardId: string; aggregateAverage: number | null; popAdjustedAverage: number | null; images: string[] }[]>('/comps/price-summary');
+  }
+
   public async getPopHistory(cardId: string, limit?: number): Promise<PopulationData[]> {
     const query = limit ? `?limit=${limit}` : '';
     return this.request<PopulationData[]>(`/comps/${cardId}/pop-history${query}`);


### PR DESCRIPTION
## Summary

- Surfaces the latest aggregate comp price (or pop-adjusted price when available) directly on each tile in the Processed Cards gallery, so users can see card value at a glance.
- Adds a lightweight backend summary endpoint that returns latest comp prices for every card with a stored report — no recompute, no schema change.
- Hydrates on page load and updates live from single-card generation and the comp-report modal's refresh action.

## Changes

- **server/database**: new `getPriceSummary()` that joins the latest `card_comp_reports` row per card with the card's image filenames.
- **server/routes**: new `GET /api/comps/price-summary` route.
- **api client**: `apiService.getPriceSummary()` typed wrapper.
- **ProcessedGallery**: `compPrices` state map, hydrated in `fetchFiles` alongside pop tiers; `trackCompPrice` callback wired into `handleGenerateComps` and the modal's `onRefresh`.
- **ProcessedGallery UI**: renders `$X.XX avg` (or `$X.XX avg (pop-adj)`) in the card-meta line; prefers pop-adjusted average when present.
- **CSS**: new `.processed-gallery-comp-price` rule (green, semi-bold, 12px).

## Test Plan

- [ ] Reload `/processed`; tiles for cards with previously-generated comps show their average price next to the file sizes.
- [ ] Click **Comps** on a tile without a stored report; once the modal opens, the tile shows the new average price without a page reload.
- [ ] Click **Refresh** inside the comp report modal; tile price updates to the new value.
- [ ] Tiles without any stored comps render normally — no `$0.00`, no placeholder.
- [ ] Graded card with pop-data shows `$X.XX avg (pop-adj)`; non-graded card shows `$X.XX avg`.
- [ ] `curl /api/comps/price-summary` returns one entry per card with stored comps and includes both `aggregateAverage` and `popAdjustedAverage`.

Closes #160