### PR TITLE
Add bulk delete for selected cards in CardList

### DIFF
--- a/src/components/CardList/CardList.css
+++ b/src/components/CardList/CardList.css
@@ -176,6 +176,7 @@
 
 .clear-selection-btn,
 .move-cards-btn,
+.bulk-delete-btn,
 .select-all-btn {
   padding: 6px 12px;
   border: none;
@@ -184,6 +185,15 @@
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s;
+}
+
+.bulk-delete-btn {
+  background: #ef4444;
+  color: #fff;
+}
+
+.bulk-delete-btn:hover {
+  background: #dc2626;
 }
 
 .clear-selection-btn {

--- a/src/components/CardList/CardList.tsx
+++ b/src/components/CardList/CardList.tsx
@@ -180,6 +180,27 @@ const CardList: React.FC<CardListProps> = ({ onCardSelect, onEditCard, selectedC
     }
   }, [selectedCards, filteredAndSortedCards]);
 
+  const handleBulkDelete = useCallback(async () => {
+    if (selectedCards.size === 0) return;
+    const count = selectedCards.size;
+    const confirmMsg = `Delete ${count} card${count !== 1 ? 's' : ''}? This cannot be undone.`;
+    if (!window.confirm(confirmMsg)) return;
+
+    const ids = Array.from(selectedCards);
+    const results = await Promise.allSettled(ids.map(id => deleteCard(id)));
+    const failed = results.filter(r => r.status === 'rejected').length;
+    const succeeded = results.length - failed;
+
+    if (failed > 0) {
+      alert(`Deleted ${succeeded} of ${count}. ${failed} failed — check the console for details.`);
+      results.forEach((r, i) => {
+        if (r.status === 'rejected') console.error(`Delete failed for ${ids[i]}:`, r.reason);
+      });
+    }
+
+    clearSelection();
+  }, [selectedCards, deleteCard, clearSelection]);
+
   const handleMoveCards = useCallback(async (cardIds: string[], targetCollectionId: string) => {
     try {
       await apiService.moveCardsToCollection(cardIds, targetCollectionId);
@@ -375,6 +396,9 @@ const CardList: React.FC<CardListProps> = ({ onCardSelect, onEditCard, selectedC
                 </button>
                 <button onClick={() => setShowMoveModal(true)} className="move-cards-btn">
                   Move to Collection
+                </button>
+                <button onClick={handleBulkDelete} className="bulk-delete-btn">
+                  Delete Selected
                 </button>
               </>
             ) : (


### PR DESCRIPTION
## Summary

- Lets users wipe out a collection in one action instead of clicking Delete + confirm on every card.
- Reuses the existing single-card DELETE endpoint (no schema or backend changes), so per-card audit log entries are preserved.
- Failures on individual deletes don't abort the batch — the user is told how many succeeded vs failed.

## Changes

- **components/CardList/CardList.tsx**: new `handleBulkDelete` that confirms with the selection count, fans out `deleteCard` calls via `Promise.allSettled`, surfaces partial-failure totals via `alert`, and clears selection on completion. New **Delete Selected** button in the bulk-selection bar (visible only when ≥1 card is selected, alongside Move to Collection / Clear Selection).
- **components/CardList/CardList.css**: `.bulk-delete-btn` styled red to match the destructive pattern used by the per-card `.delete-btn`.

## Test Plan

- [x] Open Card Inventory; click Select All; click Delete Selected; confirm — all listed cards disappear and selection clears.
- [x] Filter to a specific collection (`#collection/<id>`); Select All; Delete Selected — only that collection's cards are deleted, list refreshes empty.
- [x] Manually select a subset of cards; Delete Selected — only the chosen cards are gone.
- [x] Cancel the confirm dialog — nothing is deleted, selection remains.
- [x] Trigger a partial failure (e.g., delete one of the cards in another tab first); the alert shows the success/failure split and the console logs the rejected reasons.
- [x] No regression on Move to Collection or per-card Delete.

Closes #162