### PR TITLE
Persist enhanced card attributes server-side

### DIFF
--- a/server/drizzle/0012_card_enhanced_attributes.sql
+++ b/server/drizzle/0012_card_enhanced_attributes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cards ADD COLUMN enhancedAttributes text;

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1772755200000,
       "tag": "0011_price_alerts",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1772841600000,
+      "tag": "0012_card_enhanced_attributes",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -73,6 +73,7 @@ CREATE TABLE IF NOT EXISTS cards (
   images text DEFAULT '[]' NOT NULL,
   notes text DEFAULT '' NOT NULL,
   storageLocation text,
+  enhancedAttributes text,
   createdAt text NOT NULL,
   updatedAt text NOT NULL
 );
@@ -395,6 +396,7 @@ class Database {
       sellPrice: cardInput.sellPrice,
       sellDate: cardInput.sellDate,
       storageLocation: cardInput.storageLocation || null,
+      enhancedAttributes: cardInput.enhancedAttributes ?? null,
       currentValue: cardInput.currentValue,
       images: cardInput.images || [],
       notes: cardInput.notes || '',
@@ -431,6 +433,7 @@ class Database {
       currentValue: card.currentValue,
       images: card.images,
       storageLocation: card.storageLocation || null,
+      enhancedAttributes: card.enhancedAttributes ?? null,
       notes: card.notes,
       createdAt: card.createdAt,
       updatedAt: card.updatedAt,
@@ -477,6 +480,7 @@ class Database {
       sellDate: cardInput.sellDate || null,
       currentValue: cardInput.currentValue,
       storageLocation: cardInput.storageLocation !== undefined ? (cardInput.storageLocation || null) : existing.storageLocation,
+      enhancedAttributes: cardInput.enhancedAttributes !== undefined ? (cardInput.enhancedAttributes ?? null) : (existing.enhancedAttributes ?? null),
       images: cardInput.images || [],
       notes: cardInput.notes || '',
       updatedAt,
@@ -526,6 +530,7 @@ class Database {
       sellPrice: row.sellPrice ?? undefined,
       sellDate: row.sellDate ?? undefined,
       storageLocation: (row.storageLocation as StorageLocation | null) ?? null,
+      enhancedAttributes: (row.enhancedAttributes as Record<string, unknown> | null) ?? null,
       images: row.images ?? [],
       notes: row.notes || '',
     };

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -70,6 +70,7 @@ export const cards = sqliteTable('cards', {
     method?: string;
     notes?: string;
   } | null>(),
+  enhancedAttributes: text('enhancedAttributes', { mode: 'json' }).$type<Record<string, unknown> | null>(),
   createdAt: text('createdAt').notNull(),
   updatedAt: text('updatedAt').notNull(),
 });

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -42,6 +42,7 @@ export interface Card {
   sellDate?: string;
   currentValue: number;
   storageLocation?: StorageLocation | null;
+  enhancedAttributes?: Record<string, unknown> | null;
   images: string[];
   notes: string;
   createdAt: string;
@@ -75,6 +76,7 @@ export interface CardInput {
   sellDate?: string;
   currentValue: number;
   storageLocation?: StorageLocation | null;
+  enhancedAttributes?: Record<string, unknown> | null;
   images: string[];
   notes: string;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import PortfolioHeatmap from './components/PortfolioHeatmap/PortfolioHeatmap';
 import StorageManager from './components/StorageManager/StorageManager';
 import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary';
 import { Card } from './types';
-import { saveEnhancedCard, mergeCardWithEnhanced } from './utils/enhancedCardIntegration';
+import { saveEnhancedCard, mergeCardWithEnhanced, migrateLocalStorageEnhancedAttributes } from './utils/enhancedCardIntegration';
 import { logInfo } from './utils/logger';
 import './App.css';
 
@@ -62,6 +62,14 @@ const AppContent: React.FC = () => {
     window.addEventListener('hashchange', handleHashChange);
     return () => window.removeEventListener('hashchange', handleHashChange);
   }, []);
+
+  // One-shot drain of legacy localStorage enhanced-card payloads into the DB.
+  React.useEffect(() => {
+    if (!authState.user) return;
+    migrateLocalStorageEnhancedAttributes().catch(err => {
+      console.warn('Enhanced-attributes migration failed:', err);
+    });
+  }, [authState.user]);
 
   // Show auth form if user is not authenticated
   if (!authState.user) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -88,6 +88,7 @@ interface CardInput {
   notes: string;
   collectionId?: string;
   collectionType?: string;
+  enhancedAttributes?: Record<string, unknown> | null;
 }
 
 class ApiService {
@@ -209,7 +210,8 @@ class ApiService {
         images: cardData.images,
         notes: cardData.notes,
         collectionId: cardData.collectionId,
-        collectionType: cardData.collectionType
+        collectionType: cardData.collectionType,
+        enhancedAttributes: cardData.enhancedAttributes ?? null,
       };
 
       const card = await this.request<Card>('/cards', {
@@ -261,7 +263,8 @@ class ApiService {
         images: cardData.images,
         notes: cardData.notes,
         collectionId: cardData.collectionId,
-        collectionType: cardData.collectionType
+        collectionType: cardData.collectionType,
+        enhancedAttributes: cardData.enhancedAttributes ?? null,
       };
 
       const card = await this.request<Card>(`/cards/${cardData.id}`, {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,6 +52,7 @@ export interface Card {
   sellDate?: Date;
   currentValue: number;
   storageLocation?: StorageLocation | null;
+  enhancedAttributes?: Record<string, unknown> | null;
   images: string[];
   notes: string;
   createdAt: Date;

--- a/src/utils/enhancedCardIntegration.ts
+++ b/src/utils/enhancedCardIntegration.ts
@@ -3,6 +3,7 @@
 import { Card } from '../types';
 import { EnhancedCard } from '../types/card-enhanced';
 import { migrateCardToEnhanced, hasEnhancedFields } from './cardMigration';
+import { apiService } from '../services/api';
 
 // Convert enhanced card back to basic card for storage
 export const enhancedToBasicCard = (enhancedCard: Partial<EnhancedCard>): Card => {
@@ -43,10 +44,41 @@ export const enhancedToBasicCard = (enhancedCard: Partial<EnhancedCard>): Card =
     
     // Images & Notes - include both original notes and enhanced features
     images: enhancedCard.images || [],
-    notes: combinedNotes || ''
+    notes: combinedNotes || '',
+
+    // Persist the EnhancedCard extension blocks to the DB so they round-trip
+    // across browsers/devices. localStorage is kept as a transitional fallback.
+    enhancedAttributes: extractEnhancedAttributes(enhancedCard),
   };
-  
+
   return basicCard;
+};
+
+const ENHANCED_BLOCKS = [
+  'identification',
+  'playerMetadata',
+  'authentication',
+  'specialFeatures',
+  'marketData',
+  'physicalAttributes',
+  'storage',
+  'transaction',
+  'digital',
+  'analytics',
+  'collectionMeta',
+] as const;
+
+const extractEnhancedAttributes = (
+  enhancedCard: Partial<EnhancedCard>
+): Record<string, unknown> | null => {
+  const out: Record<string, unknown> = {};
+  for (const key of ENHANCED_BLOCKS) {
+    const value = (enhancedCard as Record<string, unknown>)[key];
+    if (value !== undefined && value !== null) {
+      out[key] = value;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null;
 };
 
 // Generate comprehensive notes from enhanced fields
@@ -116,74 +148,57 @@ const generateEnhancedNotes = (card: Partial<EnhancedCard>): string => {
   return notes.join(' | ');
 };
 
-// Store enhanced data in localStorage
-export const saveEnhancedData = (cardId: string, enhancedData: Partial<EnhancedCard>) => {
-  const key = `enhanced_card_${cardId}`;
-  const dataToStore = {
-    identification: enhancedData.identification,
-    playerMetadata: enhancedData.playerMetadata,
-    authentication: enhancedData.authentication,
-    specialFeatures: enhancedData.specialFeatures,
-    marketData: enhancedData.marketData,
-    physicalAttributes: enhancedData.physicalAttributes,
-    storage: enhancedData.storage,
-    transaction: enhancedData.transaction,
-    digital: enhancedData.digital,
-    analytics: enhancedData.analytics,
-    collectionMeta: enhancedData.collectionMeta
-  };
-  
-  console.log('Saving enhanced data for card:', cardId);
-  console.log('LocalStorage key:', key);
-  console.log('Data to store:', dataToStore);
-  
-  localStorage.setItem(key, JSON.stringify(dataToStore));
-  
-  // Verify the save
-  const saved = localStorage.getItem(key);
-  console.log('Verification - Data saved to localStorage:', saved);
-};
+// One-shot boot migration: drain any pre-existing `enhanced_card_*`
+// localStorage entries into the server-side `enhancedAttributes` column,
+// then remove them. Safe to run on every boot — it skips cards whose DB
+// record already has enhancedAttributes (DB is canonical).
+export const migrateLocalStorageEnhancedAttributes = async (): Promise<void> => {
+  const PREFIX = 'enhanced_card_';
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i);
+    if (k && k.startsWith(PREFIX)) keys.push(k);
+  }
+  if (keys.length === 0) return;
 
-// Retrieve enhanced data from localStorage
-export const loadEnhancedData = (cardId: string): Partial<EnhancedCard> | null => {
-  const key = `enhanced_card_${cardId}`;
-  const data = localStorage.getItem(key);
-  
-  console.log('Loading enhanced data for card:', cardId);
-  console.log('LocalStorage key:', key);
-  console.log('Raw data from localStorage:', data);
-  
-  if (data) {
+  console.log(`[migrateLocalStorageEnhancedAttributes] Found ${keys.length} legacy localStorage entries`);
+
+  for (const key of keys) {
+    const cardId = key.slice(PREFIX.length);
+    let raw: string | null;
     try {
-      const parsed = JSON.parse(data);
-      console.log('Parsed enhanced data:', parsed);
-      return parsed;
-    } catch (error) {
-      console.error('Error parsing enhanced card data:', error);
-      return null;
+      raw = localStorage.getItem(key);
+    } catch { continue; }
+    if (!raw) { localStorage.removeItem(key); continue; }
+
+    let parsed: Record<string, unknown>;
+    try { parsed = JSON.parse(raw); }
+    catch { localStorage.removeItem(key); continue; }
+
+    try {
+      const card = await apiService.getCard(cardId);
+      if (card.enhancedAttributes) {
+        // DB already has data — DB wins, drop the stale localStorage copy.
+        localStorage.removeItem(key);
+        continue;
+      }
+      await apiService.updateCard({ ...card, enhancedAttributes: parsed });
+      localStorage.removeItem(key);
+    } catch (err) {
+      // Card no longer exists or API down — leave the entry for a retry.
+      console.warn(`[migrateLocalStorageEnhancedAttributes] Skipped ${cardId}:`, err);
     }
   }
-  
-  console.log('No enhanced data found for card:', cardId);
-  return null;
 };
 
-// Merge basic card with enhanced data
+// Merge basic card with enhanced data (server-side `enhancedAttributes` only).
+// localStorage is no longer consulted; any pre-existing localStorage payload
+// is migrated to the DB on app boot via `migrateLocalStorageEnhancedAttributes`.
 export const mergeCardWithEnhanced = (card: Card): EnhancedCard => {
-  console.log('Merging card with enhanced data:', card.id);
-  const enhancedData = loadEnhancedData(card.id);
-  
-  if (enhancedData) {
-    console.log('Found enhanced data, merging with basic card');
-    const merged = {
-      ...card,
-      ...enhancedData
-    };
-    console.log('Merged card data:', merged);
-    return merged;
+  const dbAttributes = (card.enhancedAttributes ?? null) as Record<string, unknown> | null;
+  if (dbAttributes) {
+    return { ...card, ...dbAttributes } as EnhancedCard;
   }
-  
-  console.log('No enhanced data found, migrating card to enhanced format');
   return migrateCardToEnhanced(card);
 };
 
@@ -194,14 +209,12 @@ export const saveEnhancedCard = async (
   updateCard: (card: Card) => Promise<void>
 ): Promise<void> => {
   console.log('[saveEnhancedCard] Starting save process for enhanced card:', enhancedCard);
-  
-  // Convert to basic card for database
+
+  // Convert to basic card for database. enhancedAttributes is packed in by
+  // enhancedToBasicCard so the full enhanced payload round-trips via the API.
   const basicCard = enhancedToBasicCard(enhancedCard);
   console.log('[saveEnhancedCard] Converted to basic card:', basicCard);
-  
-  // Save enhanced data to localStorage
-  saveEnhancedData(basicCard.id, enhancedCard);
-  
+
   // Save to database
   // Check if this is an update (card has an ID and was created before)
   const isUpdate = enhancedCard.id && enhancedCard.createdAt;


### PR DESCRIPTION
## Summary

- Moves the EnhancedCard extension blocks (era, cardSize, autograph color, jersey number, market data, etc.) from browser `localStorage` to the SQLite `cards` table so they round-trip across browsers and devices.
- Single nullable JSON column `enhancedAttributes` keeps the schema forward-compatible — no per-field migration churn for the ~155 leaf fields across 11 EnhancedCard blocks.
- Includes a one-shot boot-time drain that lifts any pre-existing `enhanced_card_*` localStorage payloads into the DB, so existing browser data isn't lost.

## Changes

- **server/db**: new drizzle migration `0012_card_enhanced_attributes.sql` adding nullable JSON column `cards.enhancedAttributes`; schema, BASELINE SQL, and Card/CardInput types updated.
- **server/database**: column wired through `mapCardRow`, `createCard`, and `updateCard` (update preserves existing value when the field is omitted in the payload).
- **api-client**: `Card` and `CardInput` extended; `apiService.createCard` / `updateCard` forward the field.
- **enhanced-card integration**: `enhancedToBasicCard` packs the 11 extension blocks into `enhancedAttributes` for the API write; `mergeCardWithEnhanced` reads only from `card.enhancedAttributes`; `saveEnhancedCard` no longer writes to localStorage; dead exports `saveEnhancedData` / `loadEnhancedData` removed.
- **migration utility**: new `migrateLocalStorageEnhancedAttributes` scans `enhanced_card_*` keys on boot, pushes each into the matching card via the API, then removes the key (DB wins when both exist).
- **App boot**: hook calls the migration once after auth.

## Test Plan

- [x] On a fresh DB, open a card in the EnhancedCardForm, set `era` and `cardSize`, save; reload in a different browser — values persist.
- [x] On a browser with an existing `enhanced_card_<id>` localStorage entry whose card has no DB `enhancedAttributes`: log in, observe the entry is removed from localStorage and the values appear in the DB (`SELECT enhancedAttributes FROM cards WHERE id=...`).
- [x] On a card whose DB row already has `enhancedAttributes`, verify the boot migration leaves it alone (DB wins) and removes the stale localStorage copy.
- [x] Existing per-card actions (basic Edit, Delete, Move to Collection) still work end-to-end.
- [x] `curl /api/cards/:id` returns `enhancedAttributes` in the response.

Closes #164