### PR TITLE
Inventory + eBay export UX polish

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -1822,6 +1822,15 @@ class Database {
     return result.changes > 0;
   }
 
+  public async getExportedCardIds(): Promise<string[]> {
+    const rows = this.sqlite.prepare(`
+      SELECT DISTINCT json_extract(value, '$.cardId') AS cardId
+      FROM ebay_export_drafts, json_each(ebay_export_drafts.cardSummary)
+      WHERE json_extract(value, '$.cardId') IS NOT NULL
+    `).all() as { cardId: string }[];
+    return rows.map(r => r.cardId);
+  }
+
   // ─── Card Image Uploads ────────────────────────────────────────────────────
 
   public async saveImageUpload(upload: { cardId: string; filename: string; remoteUrl: string; fileHash: string }): Promise<ImageUpload> {

--- a/server/src/routes/ebay.ts
+++ b/server/src/routes/ebay.ts
@@ -117,6 +117,19 @@ export function createEbayRoutes(db: Database, ebayExportService: EbayExportServ
     }
   });
 
+  // GET /api/ebay/exported-card-ids — Return a deduped list of card ids that
+  // appear in any export draft. Used by the inventory UI to flag exported
+  // cards with an "eBay" pill.
+  router.get('/exported-card-ids', async (_req: Request, res: Response) => {
+    try {
+      const ids = await db.getExportedCardIds();
+      res.json(ids);
+    } catch (error) {
+      console.error('Error getting exported card ids:', error);
+      res.status(500).json({ error: 'Failed to get exported card ids' });
+    }
+  });
+
   // GET /api/ebay/drafts — List export drafts (paginated)
   router.get('/drafts', async (_req: Request, res: Response) => {
     try {

--- a/server/src/services/ebayExportService.ts
+++ b/server/src/services/ebayExportService.ts
@@ -284,16 +284,37 @@ class EbayExportService {
   }
 
   private generateSku(card: Card): string {
-    const lastName = card.player.split(' ').pop()?.toUpperCase() || 'UNKNOWN';
-    const year = card.year.toString();
-    const cardNum = card.cardNumber;
+    const sanitize = (s: string) => s.toUpperCase().replace(/[^A-Z0-9]/g, '');
 
-    if (card.isGraded && card.gradingCompany && card.grade) {
-      const grade = card.grade.replace('.', '');
-      return `${lastName}-${year}-${cardNum}-${card.gradingCompany}${grade}`;
+    const lastName = sanitize(card.player.split(' ').pop() || 'UNKNOWN');
+    const year = card.year > 0 ? card.year.toString() : 'YR';
+
+    // Product slot: prefer the set name, fall back to the brand.
+    const product = sanitize(card.setName || card.brand || '');
+
+    // Parallel slot: optional, only when set.
+    const parallel = card.parallel ? sanitize(card.parallel) : '';
+
+    // Copy slot: prefer the unique serial number (e.g. "76" from "76/99"),
+    // fall back to the printed card number, then to the last 7 of the UUID
+    // so unnumbered base cards still get a unique SKU.
+    let copy = '';
+    if (card.serialNumber && card.serialNumber.includes('/')) {
+      copy = sanitize(card.serialNumber.split('/')[0]);
+    } else if (card.cardNumber) {
+      copy = sanitize(card.cardNumber);
+    } else {
+      copy = card.id.replace(/-/g, '').slice(-7).toLowerCase();
     }
 
-    return `${lastName}-${year}-${cardNum}-RAW`;
+    // Grade slot: PSA10 / RAW.
+    const gradeSlot = card.isGraded && card.gradingCompany && card.grade
+      ? `${sanitize(card.gradingCompany)}${card.grade.replace('.', '')}`
+      : 'RAW';
+
+    return [lastName, year, product, parallel, copy, gradeSlot]
+      .filter(s => s && s.length > 0)
+      .join('-');
   }
 
   private generateTitle(card: Card): string {
@@ -311,7 +332,9 @@ class EbayExportService {
       parts.push(card.parallel);
     }
 
-    parts.push(`#${card.cardNumber}`);
+    if (card.cardNumber) {
+      parts.push(`#${card.cardNumber}`);
+    }
 
     if (card.gradingCompany && card.grade) {
       parts.push(`${card.gradingCompany} ${card.grade}`);
@@ -323,6 +346,14 @@ class EbayExportService {
 
     if (card.team) {
       parts.push(card.team);
+    }
+
+    // Append print-run suffix (e.g. "/99") when serialNumber is "<n>/<printRun>".
+    const printRun = card.serialNumber && card.serialNumber.includes('/')
+      ? card.serialNumber.split('/')[1].trim()
+      : null;
+    if (printRun) {
+      parts.push(`/${printRun}`);
     }
 
     let title = parts.join(' ');

--- a/src/components/BreakEvenCalculator/BreakEvenCalculator.tsx
+++ b/src/components/BreakEvenCalculator/BreakEvenCalculator.tsx
@@ -80,7 +80,7 @@ export const BreakEvenCalculator: React.FC<BreakEvenCalculatorProps> = ({ card, 
         <div className="break-even-header">
           <div>
             <h2>Break-Even Calculator</h2>
-            <p className="break-even-card-name">{card.year} {card.brand} {card.player} #{card.cardNumber}</p>
+            <p className="break-even-card-name">{card.year} {card.brand} {card.player}{card.cardNumber ? ` #${card.cardNumber}` : ''}</p>
           </div>
           <button className="break-even-close" onClick={onClose}>x</button>
         </div>

--- a/src/components/CardList/CardList.css
+++ b/src/components/CardList/CardList.css
@@ -466,6 +466,17 @@
   color: #047857;
 }
 
+.card-ebay-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border: 1px solid #bfdbfe;
+}
+
 /* Cleaned up - these styles are now handled by the new layout */
 
 .empty-state {

--- a/src/components/CardList/CardList.tsx
+++ b/src/components/CardList/CardList.tsx
@@ -29,6 +29,7 @@ const CardList: React.FC<CardListProps> = ({ onCardSelect, onEditCard, selectedC
   const [showMoveModal, setShowMoveModal] = useState(false);
   const [popTiers, setPopTiers] = useState<Map<string, PopRarityTier>>(new Map());
   const [popPrices, setPopPrices] = useState<Map<string, number>>(new Map());
+  const [exportedIds, setExportedIds] = useState<Set<string>>(new Set());
 
   // Load pop tiers and prices
   useEffect(() => {
@@ -44,6 +45,13 @@ const CardList: React.FC<CardListProps> = ({ onCardSelect, onEditCard, selectedC
       if (tiers.size > 0) setPopTiers(tiers);
       if (prices.size > 0) setPopPrices(prices);
     }).catch(() => { /* non-critical */ });
+  }, []);
+
+  // Load the set of card ids that have been exported to eBay
+  useEffect(() => {
+    apiService.getExportedCardIds()
+      .then(ids => { if (ids.length > 0) setExportedIds(new Set(ids)); })
+      .catch(() => { /* non-critical */ });
   }, []);
 
   // Load collection info when selectedCollectionId changes
@@ -456,7 +464,7 @@ const CardList: React.FC<CardListProps> = ({ onCardSelect, onEditCard, selectedC
               <div className="card-player-name">
                 <h4>{card.player}</h4>
                 <p className="card-detail-line">
-                  {card.year} {card.brand}{card.setName ? ` ${card.setName}` : ''} #{card.cardNumber}
+                  {card.year} {card.brand}{card.setName ? ` ${card.setName}` : ''}{card.cardNumber ? ` #${card.cardNumber}` : ''}
                 </p>
                 <div className="card-pills">
                   {popTiers.has(card.id) && (
@@ -471,6 +479,9 @@ const CardList: React.FC<CardListProps> = ({ onCardSelect, onEditCard, selectedC
                     <span className="card-pop-price-badge">
                       ${popPrices.get(card.id)!.toFixed(2)}
                     </span>
+                  )}
+                  {exportedIds.has(card.id) && (
+                    <span className="card-ebay-badge" title="Exported to eBay">eBay</span>
                   )}
                 </div>
               </div>

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -147,7 +147,7 @@ const Dashboard: React.FC = () => {
                 <div key={card.id} className="card-item">
                   <div className="card-info">
                     <strong>{card.year} {card.brand} {card.player}</strong>
-                    <span>{card.team} - #{card.cardNumber}</span>
+                    <span>{card.team}{card.cardNumber ? ` - #${card.cardNumber}` : ''}</span>
                   </div>
                   <div className="card-value">
                     {formatCurrency(card.currentValue)}
@@ -168,7 +168,7 @@ const Dashboard: React.FC = () => {
                 <div key={card.id} className="card-item">
                   <div className="card-info">
                     <strong>{card.year} {card.brand} {card.player}</strong>
-                    <span>{card.team} - #{card.cardNumber}</span>
+                    <span>{card.team}{card.cardNumber ? ` - #${card.cardNumber}` : ''}</span>
                   </div>
                   <div className="card-performance">
                     <span className={`profit ${card.profit >= 0 ? 'positive' : 'negative'}`}>

--- a/src/components/EbayListings/EbayListings.tsx
+++ b/src/components/EbayListings/EbayListings.tsx
@@ -449,7 +449,7 @@ const EbayListings: React.FC = () => {
             <div className="listing-content">
               <h3>{rec.card.player}</h3>
               <p className="card-details">
-                {rec.card.year} {rec.card.brand} #{rec.card.cardNumber}
+                {rec.card.year} {rec.card.brand}{rec.card.cardNumber ? ` #${rec.card.cardNumber}` : ''}
                 {rec.card.parallel && ` - ${rec.card.parallel}`}
               </p>
 

--- a/src/components/EnhancedCardForm/EnhancedCardForm.css
+++ b/src/components/EnhancedCardForm/EnhancedCardForm.css
@@ -7,21 +7,22 @@
   margin: 0 auto;
 }
 
-.form-header {
+.enhanced-card-form .form-header {
   text-align: center;
   margin-bottom: 32px;
 }
 
-.form-header h2 {
-  color: #1a202c;
+.enhanced-card-form .form-header h2 {
+  color: #ffffff;
   font-size: 28px;
   font-weight: 700;
   margin-bottom: 8px;
 }
 
-.form-header p {
-  color: #718096;
+.enhanced-card-form .form-header p {
+  color: #ffffff;
   font-size: 16px;
+  opacity: 0.9;
 }
 
 /* Tab Navigation */

--- a/src/components/GradingTracker/GradingSubmissionForm.tsx
+++ b/src/components/GradingTracker/GradingSubmissionForm.tsx
@@ -93,7 +93,7 @@ const GradingSubmissionForm: React.FC<GradingSubmissionFormProps> = ({ submissio
                 <option value="">Select a card...</option>
                 {cards.map(card => (
                   <option key={card.id} value={card.id}>
-                    {card.year} {card.brand} {card.player} #{card.cardNumber}
+                    {card.year} {card.brand} {card.player}{card.cardNumber ? ` #${card.cardNumber}` : ''}
                   </option>
                 ))}
               </select>

--- a/src/components/ProcessedGallery/CompReportModal.tsx
+++ b/src/components/ProcessedGallery/CompReportModal.tsx
@@ -126,7 +126,7 @@ const CompReportModal: React.FC<CompReportModalProps> = ({ report, onClose, onRe
           <div>
             <h3 className="comp-report-title">{currentReport.player}</h3>
             <p className="comp-report-subtitle">
-              {currentReport.year} {currentReport.brand} #{currentReport.cardNumber}
+              {currentReport.year} {currentReport.brand}{currentReport.cardNumber ? ` #${currentReport.cardNumber}` : ''}
               {currentReport.condition && <> &middot; {currentReport.condition}</>}
             </p>
           </div>

--- a/src/components/ProcessedGallery/ProcessedGallery.tsx
+++ b/src/components/ProcessedGallery/ProcessedGallery.tsx
@@ -637,7 +637,9 @@ const ProcessedGallery: React.FC = () => {
                     <div className="processed-gallery-card-details">
                       <span className="processed-gallery-card-year">{pair.info.year}</span>
                       <span className="processed-gallery-card-brand">{pair.info.brand}{pair.info.set ? ` ${pair.info.set}` : ''}</span>
-                      <span className="processed-gallery-card-number">#{pair.info.cardNumber}</span>
+                      {pair.info.cardNumber && (
+                        <span className="processed-gallery-card-number">#{pair.info.cardNumber}</span>
+                      )}
                     </div>
                   </>
                 ) : (

--- a/src/components/StorageManager/StorageManager.tsx
+++ b/src/components/StorageManager/StorageManager.tsx
@@ -181,7 +181,7 @@ const StorageManager: React.FC = () => {
                   <div key={card.id} className="storage-card-row">
                     <div className="storage-card-info">
                       <span className="storage-card-name">
-                        {card.year} {card.brand} {card.player} #{card.cardNumber}
+                        {card.year} {card.brand} {card.player}{card.cardNumber ? ` #${card.cardNumber}` : ''}
                       </span>
                       {card.isGraded && card.gradingCompany && card.grade && (
                         <span className="storage-card-grade">{card.gradingCompany} {card.grade}</span>
@@ -272,7 +272,7 @@ const StorageManager: React.FC = () => {
                     <div key={card.id} className="storage-card-row">
                       <div className="storage-card-info">
                         <span className="storage-card-name">
-                          {card.year} {card.brand} {card.player} #{card.cardNumber}
+                          {card.year} {card.brand} {card.player}{card.cardNumber ? ` #${card.cardNumber}` : ''}
                         </span>
                         {card.isGraded && card.gradingCompany && card.grade && (
                           <span className="storage-card-grade">{card.gradingCompany} {card.grade}</span>
@@ -399,7 +399,7 @@ const StorageManager: React.FC = () => {
                       checked={selectedCardIds.includes(card.id)}
                       onChange={() => toggleCardSelection(card.id)}
                     />
-                    <span>{card.year} {card.brand} {card.player} #{card.cardNumber}</span>
+                    <span>{card.year} {card.brand} {card.player}{card.cardNumber ? ` #${card.cardNumber}` : ''}</span>
                     {card.storageLocation && (
                       <span className="storage-card-current-loc">({formatLocation(card.storageLocation)})</span>
                     )}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -386,6 +386,10 @@ class ApiService {
     return this.request('/ebay/status');
   }
 
+  public async getExportedCardIds(): Promise<string[]> {
+    return this.request<string[]>('/ebay/exported-card-ids');
+  }
+
   public async getEbayExportDrafts(limit?: number, offset?: number): Promise<{
     drafts: EbayExportDraftSummary[];
     total: number;

--- a/src/types/card-enhanced.ts
+++ b/src/types/card-enhanced.ts
@@ -176,7 +176,7 @@ export interface PhysicalAttributes {
 export interface StorageData {
   // Physical Location
   storageLocation: string;
-  storageMethod: 'Raw' | 'Penny Sleeve' | 'Toploader' | 'One-Touch' | 'Screw Down' | 'Binder' | 'Graded Slab';
+  storageMethod: 'Raw' | 'Penny Sleeve' | 'Toploader' | 'One-Touch' | 'Magnetic Card Holder' | 'Screw Down' | 'Binder' | 'Graded Slab';
   sleeveType?: 'Standard' | 'Premium' | 'Team Bag';
   
   // Organization
@@ -354,7 +354,7 @@ export type EnhancedCardFormData = Partial<EnhancedCard>;
 export const PRINTING_TECHNOLOGIES = ['Chrome', 'Paper', 'Acetate', 'Metal', 'Canvas'] as const;
 export const CARD_ERAS = ['Vintage', 'Junk Wax', 'Modern', 'Ultra-Modern'] as const;
 export const PURCHASE_VENUES = ['eBay', 'COMC', 'LCS', 'Show', 'Retail', 'Hobby Box', 'Private Sale', 'Auction House'] as const;
-export const STORAGE_METHODS = ['Raw', 'Penny Sleeve', 'Toploader', 'One-Touch', 'Screw Down', 'Binder', 'Graded Slab'] as const;
+export const STORAGE_METHODS = ['Raw', 'Penny Sleeve', 'Toploader', 'One-Touch', 'Magnetic Card Holder', 'Screw Down', 'Binder', 'Graded Slab'] as const;
 export const COLLECTION_CATEGORIES = ['PC', 'Investment', 'Trade Bait', 'Duplicate', 'Consignment'] as const;
 
 // Validation helper


### PR DESCRIPTION
## Summary

- Surfaces an **eBay** pill on inventory tiles for cards that have been included in any export draft, so it's obvious at a glance what's been listed.
- Cleans up several UI surfaces that were rendering a dangling `#` for unnumbered cards (Emanate-style products).
- Improves the eBay export itself: titles drop the empty `#` and end with the print-run suffix (`/99`, `/25`, …); SKUs use a richer slot template that keeps unnumbered cards uniquely identifiable.
- Two unrelated polish bits ride along: white-on-navy header text in the EnhancedCardForm, and a new **Magnetic Card Holder** option in Storage Method.

## Changes

- **server/db**: new `getExportedCardIds()` helper (json_each over draft cardSummary) and `GET /api/ebay/exported-card-ids` route.
- **server/ebay-export**: `generateTitle` skips empty card numbers and appends `/<printRun>` parsed from `serialNumber`; `generateSku` rewritten with `{LASTNAME}-{YEAR}-{SET-or-BRAND}-{PARALLEL}-{SERIAL-or-CARDNUM}-{GRADE-or-RAW}` slots, falling back to a 7-char UUID suffix for unnumbered base cards.
- **api-client**: `apiService.getExportedCardIds()` typed wrapper.
- **CardList**: loads exported-id set on mount, renders `.card-ebay-badge` pill in `card-pills` row alongside pop tier / pop-adjusted price.
- **UI sweep**: `CardList`, `StorageManager` (3 spots), `EbayListings`, `GradingSubmissionForm`, `BreakEvenCalculator`, `ProcessedGallery`, `CompReportModal`, `Dashboard` (recent + top performers) all hide the trailing `#` when `cardNumber` is empty.
- **EnhancedCardForm CSS**: scope `.form-header` rules under `.enhanced-card-form` so they no longer collide with `CardForm.css`'s `.form-header` (which paints the navy banner); switch title/subtitle text to white.
- **Enhanced types**: add `Magnetic Card Holder` to `STORAGE_METHODS` and the `StorageData.storageMethod` union, between One-Touch and Screw Down.

## Test Plan

- [x] Run an eBay export for any card; reload Inventory — that card shows the **eBay** pill.
- [x] Open the generated CSV and inspect Title for an Emanate card: no `#`, ends in ` /99` (or whatever print run); inspect Custom Label for the same card: matches the new SKU template.
- [x] Open an Emanate card tile in Inventory, Storage Manager, Grading Submission Form select, Break-Even Calculator, eBay Listings, Comp Report modal, Processed Gallery, Dashboard recent — none show a dangling `#`.
- [x] Open EnhancedCardForm in edit mode — "Edit Enhanced Card" title and subtitle render clearly white on the navy banner.
- [x] Open EnhancedCardForm > Storage tab — `Magnetic Card Holder` appears in the Storage Method dropdown between `One-Touch` and `Screw Down`.
- [x] No regression on already-numbered cards: title still shows `#150` and gets the print-run suffix only if numbered.