### PR TITLE
Fix ingestion dedup collision on setName / parallel

### DIFF
--- a/server/src/__tests__/services/imageProcessingService.test.ts
+++ b/server/src/__tests__/services/imageProcessingService.test.ts
@@ -85,6 +85,30 @@ describe('ImageProcessingService', () => {
       );
       expect(result).toBe('2023-Topps-Chrome-Update-Mike-Trout-1.jpg');
     });
+
+    it('appends parallel after cardNumber', () => {
+      const result = service.buildProcessedFilename(
+        { year: '2024', brand: 'Topps', setName: 'Cosmic Chrome Planetary Pursuit', player: 'Xavier Worthy', cardNumber: 'XW', parallel: 'Earth' },
+        '.jpg'
+      );
+      expect(result).toBe('2024-Topps-Cosmic-Chrome-Planetary-Pursuit-Xavier-Worthy-XW-Earth.jpg');
+    });
+
+    it('includes parallel even without setName', () => {
+      const result = service.buildProcessedFilename(
+        { year: '2024', brand: 'Topps', player: 'Xavier Worthy', cardNumber: 'XW', parallel: 'Jupiter' },
+        '.jpg'
+      );
+      expect(result).toBe('2024-Topps-Xavier-Worthy-XW-Jupiter.jpg');
+    });
+
+    it('omits parallel slot when absent', () => {
+      const result = service.buildProcessedFilename(
+        { year: '2024', brand: 'Topps', setName: 'Chrome', player: 'Mike Trout', cardNumber: '1' },
+        '.jpg'
+      );
+      expect(result).toBe('2024-Topps-Chrome-Mike-Trout-1.jpg');
+    });
   });
 
   describe('checkDuplicate', () => {
@@ -150,6 +174,73 @@ describe('ImageProcessingService', () => {
       // Verify the orphaned card was deleted
       const allCards = await db.getAllCards();
       expect(allCards.find(c => c.id === card.id)).toBeUndefined();
+    });
+
+    it('does not match when parallel differs', async () => {
+      // Existing record: Earth parallel
+      fs.writeFileSync(path.join(processedDir, 'worthy-earth.jpg'), 'data');
+      await db.createCard({
+        player: 'Xavier Worthy', team: 'Chiefs', year: 2024, brand: 'Topps',
+        setName: 'Cosmic Chrome Planetary Pursuit', parallel: 'Earth',
+        category: 'Football', cardNumber: 'XW', condition: 'Raw',
+        purchasePrice: 0, purchaseDate: '2024-01-01', currentValue: 0,
+        images: ['worthy-earth.jpg'], notes: '',
+      });
+
+      // Incoming card: same player+year+brand+#, but Jupiter parallel.
+      const result = await service.checkDuplicate({
+        player: 'Xavier Worthy', year: '2024', brand: 'Topps',
+        setName: 'Cosmic Chrome Planetary Pursuit', parallel: 'Jupiter', cardNumber: 'XW',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('does not match when setName differs', async () => {
+      fs.writeFileSync(path.join(processedDir, 'odunze-optic.jpg'), 'data');
+      await db.createCard({
+        player: 'Rome Odunze', team: 'Bears', year: 2024, brand: 'Panini',
+        setName: 'Donruss Optic', category: 'Football', cardNumber: '15', condition: 'Raw',
+        purchasePrice: 0, purchaseDate: '2024-01-01', currentValue: 0,
+        images: ['odunze-optic.jpg'], notes: '',
+      });
+
+      const result = await service.checkDuplicate({
+        player: 'Rome Odunze', year: '2024', brand: 'Panini',
+        setName: 'Absolute', cardNumber: '15',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('matches when both records lack setName and parallel', async () => {
+      fs.writeFileSync(path.join(processedDir, 'plain.jpg'), 'data');
+      await db.createCard({
+        player: 'Plain Card', team: 'Team', year: 2024, brand: 'Panini',
+        category: 'Football', cardNumber: '50', condition: 'Raw',
+        purchasePrice: 0, purchaseDate: '2024-01-01', currentValue: 0,
+        images: ['plain.jpg'], notes: '',
+      });
+
+      const result = await service.checkDuplicate({
+        player: 'Plain Card', year: '2024', brand: 'Panini', cardNumber: '50',
+      });
+      expect(result).not.toBeNull();
+    });
+
+    it('matches when setName + parallel both match exactly', async () => {
+      fs.writeFileSync(path.join(processedDir, 'full-match.jpg'), 'data');
+      await db.createCard({
+        player: 'Full Match', team: 'Team', year: 2024, brand: 'Panini',
+        setName: 'Donruss Optic', parallel: 'Holo',
+        category: 'Football', cardNumber: '7', condition: 'Raw',
+        purchasePrice: 0, purchaseDate: '2024-01-01', currentValue: 0,
+        images: ['full-match.jpg'], notes: '',
+      });
+
+      const result = await service.checkDuplicate({
+        player: 'Full Match', year: '2024', brand: 'Panini',
+        setName: 'donruss optic', parallel: 'HOLO', cardNumber: '7',
+      });
+      expect(result).not.toBeNull();
     });
   });
 

--- a/server/src/services/imageProcessingService.ts
+++ b/server/src/services/imageProcessingService.ts
@@ -423,10 +423,13 @@ class ImageProcessingService {
     const setName = data.setName ? sanitize(data.setName) : '';
     const player = sanitize(data.player || 'Unknown');
     const cardNumber = data.cardNumber || '0';
-    if (setName) {
-      return `${year}-${brand}-${setName}-${player}-${cardNumber}${ext}`;
-    }
-    return `${year}-${brand}-${player}-${cardNumber}${ext}`;
+    const parallel = data.parallel ? sanitize(data.parallel) : '';
+
+    const parts = [year, brand];
+    if (setName) parts.push(setName);
+    parts.push(player, cardNumber);
+    if (parallel) parts.push(parallel);
+    return parts.join('-') + ext;
   }
 
   private static readonly GRADE_CONDITIONS: Record<string, string> = {
@@ -491,13 +494,24 @@ class ImageProcessingService {
       return null;
     }
 
+    // Treat null/undefined/'' as equivalent so two cards both lacking the
+    // field still compare as equal. setName + parallel are part of the
+    // identity key because real-world products reuse player/year/brand/#
+    // across distinct parallels (eg. Topps Cosmic Chrome Planetary Pursuit
+    // Earth vs Jupiter, both #XW).
+    const norm = (s: string | null | undefined): string => (s ?? '').trim().toLowerCase();
+    const targetSet = norm(data.setName);
+    const targetParallel = norm(data.parallel);
+
     const allCards = await this.db.getAllCards();
     const match = allCards.find(
       card =>
         card.player.toLowerCase() === data.player!.toLowerCase() &&
         card.year === parseInt(data.year!) &&
         card.brand.toLowerCase() === data.brand!.toLowerCase() &&
-        card.cardNumber === data.cardNumber
+        card.cardNumber === data.cardNumber &&
+        norm(card.setName) === targetSet &&
+        norm(card.parallel) === targetParallel
     );
 
     if (!match) return null;


### PR DESCRIPTION
## Summary

- Stops the ingestion pipeline from silently collapsing distinct cards that share `{player, year, brand, cardNumber}` but differ on `setName` or `parallel` — a very common pattern in modern hobby products.
- Adds `parallel` to the computed processed-filename so e.g. Topps Cosmic Chrome Planetary Pursuit Earth and Jupiter parallels no longer collide on disk.
- Extends `checkDuplicate` to also compare `setName` and `parallel` so an Absolute Kaboom Horizontal isn't treated as a duplicate of a Donruss Optic Downtown.
- Grading is intentionally NOT part of the dedup key — PSA 8 and PSA 9 of the same base card still trip the existing duplicate check.

## Changes

- **server/services/imageProcessingService**: `buildProcessedFilename` rewritten to use a parts array; appends `-{sanitized parallel}` after `cardNumber` when present. New filename schema: `{year}-{brand}[-{setName}]-{player}-{cardNumber}[-{parallel}]<ext>`.
- **server/services/imageProcessingService**: `checkDuplicate` predicate extended with `norm(setName)` and `norm(parallel)` comparisons. `norm()` treats null/undefined/'' as equivalent and is case-insensitive — two cards both lacking the field still match.
- **tests**: 3 new `buildProcessedFilename` cases (parallel with setName, parallel without setName, omitted-when-absent) and 4 new `checkDuplicate` cases (differing-parallel no-match, differing-setName no-match, both-empty match, case-insensitive normalization match).

## Test Plan

- [x] Run `npx jest src/__tests__/services/imageProcessingService.test.ts` from `server/`; all 52 tests pass including the 7 new ones.
- [x] Drop a fresh raw pair for a card whose `(player, year, brand, cardNumber)` matches an existing record but whose `parallel` differs (e.g. Earth vs Jupiter of the same Cosmic Chrome XW); run batch ingestion; the new card lands in `processed/` with its parallel in the filename and gets its own DB record.
- [x] Repeat with a differing `setName` (e.g. Donruss Optic #15 vs Absolute #15 of the same player+year); both records co-exist.
- [x] Re-upload the same physical card (same player+year+brand+cardNumber+setName+parallel); the duplicate check still rejects it.
- [x] Pre-existing processed files (which lack the parallel slot) continue to work — no rename / no migration required.

Closes #167